### PR TITLE
TCX: lap distance/time/calories should not be cumulative

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -15,7 +15,7 @@ clean:
 	$(MAKE) -C ttbin clean
 	$(MAKE) -C ttwatch clean
 	$(MAKE) -C ttbincnv clean
-	$(MAKE) -c ttbinmod clean
+	$(MAKE) -C ttbinmod clean
 
 install:
 	$(MAKE) -C ttwatch install

--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@ Linux TomTom GPS Watch Utilities
 Provides two programs for communicating with TomTom GPS watches and processing
 the data they collect.
 
-1. ttwatch - USB communications program for performing various operations
-             with the watch, including downloading activity data, updating
-             GPS data, and updating firmware.
-2. ttbincnv - Post-processor allowing conversion of the ttbin file formats
-              to either (currently) csv, gpx, kml or tcx  files, using broadly
-              similar formats to the official TomTom file formats.
+1. `ttwatch` - USB communications program for performing various operations
+               with the watch, including downloading activity data, updating
+               GPS data, and updating firmware.
+2. `ttbincnv` - Post-processor allowing conversion of the ttbin file formats
+                to either (currently) csv, gpx, kml or tcx  files, using broadly
+                similar formats to the official TomTom file formats.
 
 System Requirements
 ===================
@@ -19,11 +19,11 @@ System Requirements
 This program requires the following libraries to be compiled and installed
 before attempting to build it.
 
-1. openssl (tested against version 1.0.1f, other versions may work).
+1. `openssl` (tested against version 1.0.1f, other versions may work).
    Available from http://www.openssl.org, or with your linux distribution
-1. curl (tested against version 7.38.0, other versions may work).
+1. `curl` (tested against version 7.38.0, other versions may work).
    Available from http://curl.haxx.se/download.html
-2. libusb 1.0.16 or later (tested against version 1.0.19).
+2. `libusb` 1.0.16 or later (tested against version 1.0.19).
    Available from http://sourceforge.net/projects/libusb/
 
 Build Instructions
@@ -69,18 +69,18 @@ to be connected, then automatically perform whichever operations are specified
 on the command line. The following four operations are supported, and at least
 one of them must be specified to start the daemon:
 
-1. --get-activities: Download the activity files and store them, including
+1. `--get-activities`: Download the activity files and store them, including
    converting them to other file formats as specified in the watch preferences
    downloaded from the watch.
-2. --update-gps: Updates the GPSQuickFix information in the watch from the
+2. `--update-gps`: Updates the GPSQuickFix information in the watch from the
    internet.
-3. --update-fw: Checks for firmware updates, and updates the firmware in the
+3. `--update-fw`: Checks for firmware updates, and updates the firmware in the
    watch if newer firmware is found.
-4. --set-time: Sets the time on the watch to match the local system time.
+4. `--set-time`: Sets the time on the watch to match the local system time.
 
-All four options can be specified with the -a (or --auto) option
+All four options can be specified with the `-a` (or `--auto`) option
 
-The daemon must be started as root (run by init or sudo), but the --runas
+The daemon must be started as root (run by `init` or `sudo`), but the `--runas`
 parameter can be specified to provide an alternative user (and optionally
 a group - such as the usb group mentioned above) to run as.
 
@@ -88,8 +88,8 @@ Multiple Watches
 ================
 
 The ttwatch program has support for multiple watches. When running from the
-command line a list of available watches can be displayed using the --devices
-option. A particular watch can be selected using the -d option with three
+command line a list of available watches can be displayed using the `--devices`
+option. A particular watch can be selected using the `-d` option with three
 different parameters possible:
 
 1. a 0-based index into the device list
@@ -97,7 +97,7 @@ different parameters possible:
 3. a string that matches the watch name
 
 All three pieces of information are displayed when listing available watches
-with the --devices option.
+with the `--devices` option.
 
 When running as a daemon the device cannot be specifed by index, as the list
 of devices will change over time, so this index is meaningless. However, if
@@ -112,7 +112,11 @@ Unsafe Functions
 There are various options that can be given to the ttwatch program that read
 and write raw data to/from the watch. Used incorrectly, these could destroy
 the contents of the watch. For this reason, they are disabled by default. To
-enable these options, run configure with the --with-unsafe option. Note that
+enable these options, run configure with the `--with-unsafe` option. Note that
 I don't guarantee what will happen if you use these options without really
 knowing what you are doing.
 
+It is likely possible to reset a watch with damaged firmware or file structure
+using the Recovery Mode, which requires TomTom's official MySports Connect\
+software (Windows or Mac): [information from TomTom support]
+(http://us.support.tomtom.com/app/answers/detail/a_id/17394/~/how-do-i-perform-a-reset-on-my-gps-sport-watch%3F).

--- a/ttbin/export_tcx.c
+++ b/ttbin/export_tcx.c
@@ -29,6 +29,7 @@ void export_tcx(TTBIN_FILE *ttbin, FILE *file)
     unsigned lap_heart_rate_count;
     unsigned lap_avg_heart_rate;
     unsigned lap_max_heart_rate;
+    const char *trigger_method = "Manual";
 
     if (!ttbin->gps_records.count)
         return;
@@ -59,7 +60,6 @@ void export_tcx(TTBIN_FILE *ttbin, FILE *file)
 
     fprintf(file, "            <Lap StartTime=\"%s\">\r\n", timestr);
     fputs(        "                <Intensity>Active</Intensity>\r\n"
-                  "                <TriggerMethod>Manual</TriggerMethod>\r\n"
                   "                <Track>\r\n", file);
 
     heart_rate = 0;
@@ -69,6 +69,14 @@ void export_tcx(TTBIN_FILE *ttbin, FILE *file)
     {
         switch (record->tag)
         {
+        case TAG_TRAINING_SETUP:
+            switch (record->training_setup.type)
+            {
+            case 7: trigger_method="Time";     break;
+            case 8: trigger_method="Distance"; break;
+            }
+            break;
+
         case TAG_STATUS:
             if ((record->status.status == 2) && (lap_state == 0))
                 insert_pause = 1;
@@ -96,7 +104,6 @@ void export_tcx(TTBIN_FILE *ttbin, FILE *file)
             {
                 fprintf(file, "            <Lap StartTime=\"%s\">\r\n", timestr);
                 fputs(        "                <Intensity>Active</Intensity>\r\n"
-                              "                <TriggerMethod>Manual</TriggerMethod>\r\n"
                               "                <Track>\r\n", file);
                 lap_state = 0;
             }
@@ -131,6 +138,7 @@ void export_tcx(TTBIN_FILE *ttbin, FILE *file)
                 fputs(        "                       </LX>\r\n"
                               "                    </Extensions>\r\n", file);
                 fputs(        "                </Track>\r\n", file);
+                fprintf(file, "                <TriggerMethod>%s</TriggerMethod>\r\n", trigger_method);
                 fprintf(file, "                <TotalTimeSeconds>%d</TotalTimeSeconds>\r\n", lap_time);
                 fprintf(file, "                <DistanceMeters>%.2f</DistanceMeters>\r\n", lap_distance);
                 fprintf(file, "                <MaximumSpeed>%.2f</MaximumSpeed>\r\n", lap_max_speed);
@@ -202,6 +210,7 @@ void export_tcx(TTBIN_FILE *ttbin, FILE *file)
         fputs(        "                       </LX>\r\n"
                       "                    </Extensions>\r\n", file);
         fputs(        "                </Track>\r\n", file);
+        fprintf(file, "                <TriggerMethod>%s</TriggerMethod>\r\n", trigger_method);
         fprintf(file, "                <TotalTimeSeconds>%d</TotalTimeSeconds>\r\n", lap_time);
         fprintf(file, "                <DistanceMeters>%.2f</DistanceMeters>\r\n", lap_distance);
         fprintf(file, "                <MaximumSpeed>%.2f</MaximumSpeed>\r\n", lap_max_speed);

--- a/ttbin/export_tcx.c
+++ b/ttbin/export_tcx.c
@@ -22,10 +22,10 @@ void export_tcx(TTBIN_FILE *ttbin, FILE *file)
     int lap_state;
     int insert_pause;
     float lap_avg_speed;
-    unsigned lap_time;
-    float lap_distance;
+    unsigned lap_time, lap_start_time = 0;
+    float lap_distance, lap_start_distance = 0.0f;
     float lap_max_speed;
-    unsigned lap_calories;
+    unsigned lap_calories, lap_start_calories = 0;
     unsigned lap_heart_rate_count;
     unsigned lap_avg_heart_rate;
     unsigned lap_max_heart_rate;
@@ -159,10 +159,10 @@ void export_tcx(TTBIN_FILE *ttbin, FILE *file)
             break;
         case TAG_LAP:
             lap_avg_speed = total_speed / gps_count;
-            lap_time = record->lap.total_time;
-            lap_distance = record->lap.total_distance;
+            lap_time = record->lap.total_time - lap_start_time;
+            lap_distance = record->lap.total_distance - lap_start_distance;
             lap_max_speed = max_speed;
-            lap_calories = record->lap.total_calories;
+            lap_calories = record->lap.total_calories - lap_start_calories;
             lap_heart_rate_count = heart_rate_count;
             if (heart_rate_count > 0)
                 lap_avg_heart_rate = (total_heart_rate + (heart_rate_count >> 1)) / heart_rate_count;
@@ -174,6 +174,9 @@ void export_tcx(TTBIN_FILE *ttbin, FILE *file)
             max_heart_rate = 0;
             total_heart_rate = 0;
             lap_state = 2;
+            lap_start_time = record->lap.total_time;
+            lap_start_distance = record->lap.total_distance;
+            lap_start_calories = record->lap.total_calories;
             break;
         }
     }
@@ -183,10 +186,10 @@ void export_tcx(TTBIN_FILE *ttbin, FILE *file)
         if (!lap_state)
         {
             lap_avg_speed = total_speed / gps_count;
-            lap_time = ttbin->duration;
-            lap_distance = ttbin->total_distance;
+            lap_time = ttbin->duration - lap_start_time;
+            lap_distance = ttbin->total_distance - lap_start_distance;
             lap_max_speed = max_speed;
-            lap_calories = ttbin->total_calories;
+            lap_calories = ttbin->total_calories - lap_start_calories;
             lap_heart_rate_count = heart_rate_count;
             if (heart_rate_count > 0)
                 lap_avg_heart_rate = (total_heart_rate + (heart_rate_count >> 1)) / heart_rate_count;

--- a/ttbin/export_tcx.c
+++ b/ttbin/export_tcx.c
@@ -32,9 +32,17 @@ void export_tcx(TTBIN_FILE *ttbin, FILE *file)
     unsigned lap_max_heart_rate;
     unsigned lap_step_count;
     const char *trigger_method = "Manual";
+    const char *model;
 
     if (!ttbin->gps_records.count)
         return;
+
+    switch(ttbin->product_id)
+    {
+    case 0x03e9: model="Runner GPS Sport Watch"; break;
+    case 0x03ea: model="Multi-Sport GPS Sport Watch"; break;
+    default:     model="GPS Sport Watch"; break;
+    }
 
     fputs("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n"
           "<TrainingCenterDatabase xsi:schemaLocation=\"http://www.garmin.com/xmlschemas/TrainingCenterDatabase/v2"
@@ -243,10 +251,10 @@ void export_tcx(TTBIN_FILE *ttbin, FILE *file)
         fputs(        "            </Lap>\r\n", file);
     }
 
-    fputs(        "            <Creator xsi:type=\"Device_t\">\r\n"
-                  "                <Name>TomTom GPS Sport Watch</Name>\r\n"
-                  "                <UnitId>0</UnitId>\r\n"
-                  "                <ProductID>0</ProductID>\r\n"
+    fputs(        "            <Creator xsi:type=\"Device_t\">\r\n", file);
+    fprintf(file, "                <Name>TomTom %s</Name>\r\n", model);
+    fprintf(file, "                <ProductID>%d</ProductID>\r\n", ttbin->product_id);
+    fputs(        "                <UnitId>0</UnitId>\r\n"
                   "                <Version>\r\n", file);
     fprintf(file, "                    <VersionMajor>%d</VersionMajor>\r\n", ttbin->firmware_version[0]);
     fprintf(file, "                    <VersionMinor>%d</VersionMinor>\r\n", ttbin->firmware_version[1]);

--- a/ttbin/export_tcx.c
+++ b/ttbin/export_tcx.c
@@ -126,7 +126,7 @@ void export_tcx(TTBIN_FILE *ttbin, FILE *file)
             if (lap_state == 2)
             {
                 fputs(        "                    <Extensions>\r\n"
-                              "                       <LX xmlns=\"http://www.garmin.com/xmlschemas/ActivityExtension/vs\">\r\n", file);
+                              "                       <LX xmlns=\"http://www.garmin.com/xmlschemas/ActivityExtension/v2\">\r\n", file);
                 fprintf(file, "                           <AvgSpeed>%.5f</AvgSpeed>\r\n", lap_avg_speed);
                 fputs(        "                       </LX>\r\n"
                               "                    </Extensions>\r\n", file);
@@ -194,7 +194,7 @@ void export_tcx(TTBIN_FILE *ttbin, FILE *file)
         }
 
         fputs(        "                    <Extensions>\r\n"
-                      "                       <LX xmlns=\"http://www.garmin.com/xmlschemas/ActivityExtension/vs\">\r\n", file);
+                      "                       <LX xmlns=\"http://www.garmin.com/xmlschemas/ActivityExtension/v2\">\r\n", file);
         fprintf(file, "                           <AvgSpeed>%.5f</AvgSpeed>\r\n", lap_avg_speed);
         fputs(        "                       </LX>\r\n"
                       "                    </Extensions>\r\n", file);

--- a/ttbin/ttbin.c
+++ b/ttbin/ttbin.c
@@ -823,7 +823,9 @@ const char *create_filename(TTBIN_FILE *ttbin, const char *ext)
     case ACTIVITY_TREADMILL: type = "Treadmill"; break;
     case ACTIVITY_FREESTYLE: type = "Freestyle"; break;
     }
-    sprintf(filename, "%s_%02d-%02d-%02d.%s", type, time->tm_hour, time->tm_min, time->tm_sec, ext);
+    sprintf(filename, "%04d-%02d-%02dT%02d:%02d:%02d_%s.%s",
+            time->tm_year+1900, time->tm_mon+1, time->tm_mday,
+            time->tm_hour, time->tm_min, time->tm_sec, type, ext);
 
     return filename;
 }

--- a/ttwatch/ttwatch.c
+++ b/ttwatch/ttwatch.c
@@ -633,15 +633,9 @@ void do_get_activities(libusb_device_handle *device, const char *store, uint32_t
 
         gmtime_r(&ttbin->timestamp_local, &timestamp);
 
-        /* create the directory name: [store]/[watch name]/[date] */
-        strcpy(filename, store);
-        strcat(filename, "/");
-        if (!get_watch_name(device, filename + strlen(filename), sizeof(filename) - strlen(filename)))
-            strcat(filename, "/");
-        sprintf(filename + strlen(filename), "%04d-%02d-%02d",
-            timestamp.tm_year + 1900, timestamp.tm_mon + 1, timestamp.tm_mday);
-        _mkdir(filename);
-        chdir(filename);
+        /* place output files directly in directory */
+        _mkdir(store);
+        chdir(store);
 
         /* create the file name */
         sprintf(filename, "%s", create_filename(ttbin, "ttbin"));


### PR DESCRIPTION
1. The TCX file output should include per-lap distance/time/calories rather than cumulative values. The cumulative version really confuses Strava and Garmin Connect.

    I'm guessing you were emulating the behavior of the Windows client for TomTom MySports, which *also* outputs cumulative lap values.

2. Tweaked the `FILE_HEADER` structure so it contains a zero-size "flexible array" of `RECORD_LENGTH` at the end. This simplifies calculations involving `sizeof(FILE_HEADER)`.

     Not really an important change, just something I noticed while digging around in the code.

3. Small typo in `Makefile.in` prevents `make clean` from working after `configure`.