### PR TITLE
- fix Makefile.in so that 'make clean' works after a configure.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -15,7 +15,7 @@ clean:
 	$(MAKE) -C ttbin clean
 	$(MAKE) -C ttwatch clean
 	$(MAKE) -C ttbincnv clean
-	$(MAKE) -c ttbinmod clean
+	$(MAKE) -C ttbinmod clean
 
 install:
 	$(MAKE) -C ttwatch install

--- a/README.md
+++ b/README.md
@@ -76,18 +76,18 @@ to be connected, then automatically perform whichever operations are specified
 on the command line. The following four operations are supported, and at least
 one of them must be specified to start the daemon:
 
-1. --get-activities: Download the activity files and store them, including
+1. `--get-activities`: Download the activity files and store them, including
    converting them to other file formats as specified in the watch preferences
    downloaded from the watch.
-2. --update-gps: Updates the GPSQuickFix information in the watch from the
+2. `--update-gps`: Updates the GPSQuickFix information in the watch from the
    internet.
-3. --update-fw: Checks for firmware updates, and updates the firmware in the
+3. `--update-fw`: Checks for firmware updates, and updates the firmware in the
    watch if newer firmware is found.
-4. --set-time: Sets the time on the watch to match the local system time.
+4. `--set-time`: Sets the time on the watch to match the local system time.
 
-All four options can be specified with the -a (or --auto) option
+All four options can be specified with the `-a` (or `--auto`) option
 
-The daemon must be started as root (run by init or sudo), but the --runas
+The daemon must be started as root (run by init or sudo), but the `--runas`
 parameter can be specified to provide an alternative user (and optionally
 a group - such as the usb group mentioned above) to run as.
 
@@ -95,8 +95,8 @@ Multiple Watches
 ================
 
 The ttwatch program has support for multiple watches. When running from the
-command line a list of available watches can be displayed using the --devices
-option. A particular watch can be selected using the -d option with three
+command line a list of available watches can be displayed using the `--devices`
+option. A particular watch can be selected using the `-d` option with three
 different parameters possible:
 
 1. a 0-based index into the device list
@@ -104,7 +104,7 @@ different parameters possible:
 3. a string that matches the watch name
 
 All three pieces of information are displayed when listing available watches
-with the --devices option.
+with the `--devices` option.
 
 When running as a daemon the device cannot be specifed by index, as the list
 of devices will change over time, so this index is meaningless. However, if
@@ -119,7 +119,66 @@ Unsafe Functions
 There are various options that can be given to the ttwatch program that read
 and write raw data to/from the watch. Used incorrectly, these could destroy
 the contents of the watch. For this reason, they are disabled by default. To
-enable these options, run configure with the --with-unsafe option. Note that
+enable these options, run `configure` with the `--with-unsafe` option. Note that
 I don't guarantee what will happen if you use these options without really
 knowing what you are doing.
+
+Config Files
+============
+
+The `ttwatch` program supports loading some settings from config files. Three
+config files can be used: global, per-user, and per-watch. They are located
+in the following locations:
+
+1. `/etc/ttwatch.conf`
+2. `~/.ttwatch`
+3. `[activity-store-location]/[watch-name]/ttwatch.conf`
+
+This means that some settings can be overridden by specific users or by which
+watch is being used. Note that the per-watch settings are used either by the
+daemon (when a watch is connected), or when downloading activities from the
+command-line, not for any other operations. The per-user config file is not
+used when being run as root.
+
+The config files are very simple, and are just lines in a "option = value"
+format. '#' is used to denote a comment; anything after a '#' is ignored.
+Applicable options (*not* case sensitive) and their values are as follows:
+
+1. ActivityStore: specifies an absolute path to the place where activities
+                  are stored. Relative paths (and paths such as ~) cannot be
+                  used. This is a string value.
+2. PostProcessor: specifies a script or executable that is executed for every
+                  activity that is downloaded from the watch, with the
+                  filename of the ttbin file as the only argument. The
+                  executable is run from the directory that the ttbin file is
+                  stored in. Note that for security reasons, this executable
+                  is *not* called if the program is running as root. This is
+                  a string value.
+3. RunAsUser: this can only be specified in the global `/etc/ttwatch.conf`
+              file, and indicates which user (and optionally which group) the
+              daemon runs as, similarly to the command-line argument. An
+              error is shown if this option is specified in a non-global
+              config file. This is a string value.
+4. SkipElevation: tells the program to skip downloaded elevation data from
+                  the internet for each downloaded activity. This is a
+                  boolean value.
+5. Device: specifies which device to use, as per the `-d` (`--device`)
+           command-line parameter. Note that only one device can be specified
+           at the moment (if anyone wants to modify the code to work with
+           multiple device names here, feel free to send me a patch). This is
+           a string value.
+
+The following options only take effect when running as a daemon:
+
+1. UpdateFirmware: tells the daemon to check and update the firmware of any
+                   watch that is connected. This is a boolean value.
+2. UpdateGPS: tells the daemon to update the QuickGPSFix data of any watch
+              that is connected. This is a boolean value.
+3. SetTime: tells the daemon to update the time of any watch that is
+            connected. This is a boolean value.
+4. GetActivities: tells the daemon to download any activities from any watch
+                  that is connected. This is a boolean value.
+
+Boolean values can have a value of ('y', 'yes', 'true', 'n', 'no' or 'false').
+These values are *not* case-sensitive.
 

--- a/ttwatch/Makefile
+++ b/ttwatch/Makefile
@@ -4,6 +4,7 @@ LDFLAGS += -L../ttbin -lttbin -lusb-1.0 -lcurl -lc -lgcc -lm
 SRC = ttwatch.c \
       messages.c \
       log.c \
+      options.c \
 
 OUTPUT = ttwatch
 

--- a/ttwatch/options.c
+++ b/ttwatch/options.c
@@ -1,0 +1,207 @@
+/******************************************************************************\
+** options.c                                                                  **
+** Implementation of basic config file loading                                **
+\******************************************************************************/
+
+#include "options.h"
+
+#include <memory.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/*****************************************************************************/
+int split_conf_line(char *line, char **option, char **value)
+{
+    char *first, *last;
+    last = strchr(line, '=');
+    if (!last)
+        return 0;
+
+    *option = *value = 0;
+
+    /* extract the option name */
+    first = line;
+    while (isspace(*first))
+        ++first;
+    --last;
+    while (isspace(*last))
+        --last;
+    if (last > first)
+    {
+        *option = malloc(last - first + 1 + 1);
+        memcpy(*option, first, last - first + 1);
+        (*option)[last - first + 1] = 0;
+    }
+
+    if (*option)
+    {
+        /* extract the option value */
+        first = strchr(line, '=') + 1;
+        while (*first && isspace(*first))
+            ++first;
+        last = first + strlen(first) - 1;
+        while (isspace(*last))
+            --last;
+        if (last > first)
+        {
+            *value = malloc(last - first + 1 + 1);
+            memcpy(*value, first, last - first + 1);
+            (*value)[last - first + 1] = 0;
+        }
+    }
+
+    return 1;
+}
+
+/*****************************************************************************/
+int get_bool(char *value, int *result)
+{
+    if (!strcasecmp(value, "y") || !strcasecmp(value, "yes") || !strcasecmp(value, "true"))
+    {
+        *result = 1;
+        return 1;
+    }
+    else if (!strcasecmp(value, "n") || !strcasecmp(value, "no") || !strcasecmp(value, "false"))
+    {
+        *result = 0;
+        return 1;
+    }
+    return 0;
+}
+
+/*****************************************************************************/
+void load_conf_file(const char *filename, OPTIONS *options, ConfLoadType load_type)
+{
+    char str[256];
+    FILE *file = 0;
+    int global = 0;
+
+    /* open the conf file */
+    file = fopen(filename, "r");
+    if (!file)
+        return;
+
+    write_log(0, "Loading %s\n", filename);
+
+    while (!feof(file))
+    {
+        char *option, *value;
+        int result = 0;
+
+        if (!fgets(str, sizeof(str), file))
+            break;
+
+        /* remove any comments in the line */
+        option = strchr(str, '#');
+        if (option)
+            *option = 0;    /* truncate the line at the '#' */
+
+        /* check for a blank line */
+        option = str;
+        while (*option && isspace(*option))
+            ++option;
+        if (!*option)
+            continue;
+
+        /* make sure the line is valid */
+        if (!split_conf_line(str, &option, &value))
+        {
+            write_log(1, "Invalid conf file line: %s\n", str);
+            continue;
+        }
+        if (!option)
+            continue;
+
+        /* look for valid options/values */
+        if (!strcasecmp(option, "ActivityStore"))
+        {
+            if (load_type != LoadDaemonOperations)
+            {
+                options->activity_store = value;
+                value = 0;
+            }
+            result = 1;
+        }
+        else if (!strcasecmp(option, "Formats"))
+        {
+            if (load_type != LoadDaemonOperations)
+            {
+                options->formats = value;
+                value = 0;
+            }
+            result = 1;
+        }
+        else if (!strcasecmp(option, "PostProcessor"))
+        {
+            if (load_type != LoadDaemonOperations)
+            {
+                options->post_processor = value;
+                value = 0;
+            }
+            result = 1;
+        }
+        else if (!strcasecmp(option, "RunAsUser"))
+        {
+            result = global;
+            if (load_type != LoadDaemonOperations)
+            {
+                if (global)
+                {
+                    options->run_as = 1;
+                    options->run_as_user = value;
+                }
+            }
+        }
+        else if (!strcasecmp(option, "Device"))
+        {
+            if (load_type != LoadDaemonOperations)
+            {
+                options->select_device = 1;
+                options->device = value;
+                value = 0;
+            }
+            result = 1;
+        }
+        else if (!strcasecmp(option, "UpdateFirmware"))
+        {
+            result = 1;
+            if (load_type != LoadSettingsOnly)
+                result = get_bool(value, &options->update_firmware);
+        }
+        else if (!strcasecmp(option, "UpdateGPS"))
+        {
+            result = 1;
+            if (load_type != LoadSettingsOnly)
+                result = get_bool(value, &options->update_gps);
+        }
+        else if (!strcasecmp(option, "SetTime"))
+        {
+            result = 1;
+            if (load_type != LoadSettingsOnly)
+                result = get_bool(value, &options->set_time);
+        }
+        else if (!strcasecmp(option, "GetActivities"))
+        {
+            result = 1;
+            if (load_type != LoadSettingsOnly)
+                result = get_bool(value, &options->get_activities);
+        }
+        if (!strcasecmp(option, "SkipElevation"))
+            result = get_bool(value, &options->skip_elevation);
+
+        if (!result)
+            write_log(0, "Invalid conf file line: %s\n", str);
+
+        if (option)
+            free(option);
+        if (value)
+            free(value);
+
+        if (!result)
+            break;
+    }
+
+    fclose(file);
+}
+

--- a/ttwatch/options.h
+++ b/ttwatch/options.h
@@ -1,0 +1,62 @@
+/******************************************************************************\
+** options.h                                                                  **
+** Interface of basic config file loading                                     **
+\******************************************************************************/
+
+#include <stdint.h>
+
+typedef struct
+{
+    int update_firmware;
+    int update_gps;
+#ifdef UNSAFE
+    int list_files;
+    int read_file;
+    int write_file;
+    uint32_t file_id;
+#endif
+    int select_device;
+    char *device;
+    int show_versions;
+    int list_devices;
+    int get_time;
+    int set_time;
+    int get_activities;
+    int get_name;
+    int set_name;
+    char *watch_name;
+    int list_formats;
+    int set_formats;
+    char *formats;
+    int daemon_mode;
+    int run_as;
+    char *run_as_user;
+#ifdef UNSAFE
+    char *file;
+#endif
+    char *activity_store;
+    int list_races;
+    int update_race;
+    char *race;
+    int list_history;
+    int delete_history;
+    char *history_entry;
+    int clear_data;
+    int display_settings;
+    int setting;
+    char *setting_spec;
+    int list_settings;
+    int skip_elevation;
+    char *post_processor;
+} OPTIONS;
+
+/*****************************************************************************/
+typedef enum
+{
+    LoadAll,
+    LoadSettingsOnly,
+    LoadDaemonOperations
+} ConfLoadType;
+
+void load_conf_file(const char *filename, OPTIONS *options, ConfLoadType type);
+


### PR DESCRIPTION
- add support for loading some settings from global, per-user and per-watch config files.
- add support for running a post-processor on activity files downloaded from the watch, such as internet upload, database insertion etc.
- update README.md for the config file details