### PR TITLE
add run cadence and lap summary statistics (average cadence and total steps)

### DIFF
--- a/ttbin/export_tcx.c
+++ b/ttbin/export_tcx.c
@@ -23,10 +23,10 @@ void export_tcx(TTBIN_FILE *ttbin, FILE *file)
     int lap_state;
     int insert_pause;
     float lap_avg_speed;
-    unsigned lap_time;
-    float lap_distance;
+    unsigned lap_time, lap_start_time = 0;
+    float lap_distance, lap_start_distance = 0.0f;
     float lap_max_speed;
-    unsigned lap_calories;
+    unsigned lap_calories, lap_start_calories = 0;
     unsigned lap_heart_rate_count;
     unsigned lap_avg_heart_rate;
     unsigned lap_max_heart_rate;
@@ -169,10 +169,10 @@ void export_tcx(TTBIN_FILE *ttbin, FILE *file)
             break;
         case TAG_LAP:
             lap_avg_speed = total_speed / gps_count;
-            lap_time = record->lap.total_time;
-            lap_distance = record->lap.total_distance;
+            lap_time = record->lap.total_time - lap_start_time;
+            lap_distance = record->lap.total_distance - lap_start_distance;
             lap_max_speed = max_speed;
-            lap_calories = record->lap.total_calories;
+            lap_calories = record->lap.total_calories - lap_start_calories;
             lap_heart_rate_count = heart_rate_count;
             if (heart_rate_count > 0)
                 lap_avg_heart_rate = (total_heart_rate + (heart_rate_count >> 1)) / heart_rate_count;
@@ -186,6 +186,9 @@ void export_tcx(TTBIN_FILE *ttbin, FILE *file)
             total_heart_rate = 0;
             total_step_count = 0;
             lap_state = 2;
+            lap_start_time = record->lap.total_time;
+            lap_start_distance = record->lap.total_distance;
+            lap_start_calories = record->lap.total_calories;
             break;
         }
     }
@@ -195,10 +198,10 @@ void export_tcx(TTBIN_FILE *ttbin, FILE *file)
         if (!lap_state)
         {
             lap_avg_speed = total_speed / gps_count;
-            lap_time = ttbin->duration;
-            lap_distance = ttbin->total_distance;
+            lap_time = ttbin->duration - lap_start_time;
+            lap_distance = ttbin->total_distance - lap_start_distance;
             lap_max_speed = max_speed;
-            lap_calories = ttbin->total_calories;
+            lap_calories = ttbin->total_calories - lap_start_calories;
             lap_heart_rate_count = heart_rate_count;
             if (heart_rate_count > 0)
                 lap_avg_heart_rate = (total_heart_rate + (heart_rate_count >> 1)) / heart_rate_count;

--- a/ttbin/export_tcx.c
+++ b/ttbin/export_tcx.c
@@ -18,6 +18,7 @@ void export_tcx(TTBIN_FILE *ttbin, FILE *file)
     uint32_t max_heart_rate = 0;
     uint32_t heart_rate_count = 0;
     uint32_t gps_count = 0;
+    uint32_t total_step_count = 0;
     unsigned heart_rate;
     int lap_state;
     int insert_pause;
@@ -29,6 +30,7 @@ void export_tcx(TTBIN_FILE *ttbin, FILE *file)
     unsigned lap_heart_rate_count;
     unsigned lap_avg_heart_rate;
     unsigned lap_max_heart_rate;
+    unsigned lap_step_count;
 
     if (!ttbin->gps_records.count)
         return;
@@ -120,6 +122,11 @@ void export_tcx(TTBIN_FILE *ttbin, FILE *file)
             fputs(        "                        <Extensions>\r\n"
                           "                            <TPX xmlns=\"http://www.garmin.com/xmlschemas/ActivityExtension/v2\">\r\n", file);
             fprintf(file, "                                <Speed>%.2f</Speed>\r\n", record->gps.instant_speed);
+            if (ttbin->activity==ACTIVITY_RUNNING)
+            {
+                fprintf(file, "                                <RunCadence>%d</RunCadence>\r\n", 30*(int)record->gps.cycles);
+                total_step_count += record->gps.cycles;
+            }
             fputs(        "                            </TPX>\r\n"
                           "                        </Extensions>\r\n"
                           "                    </Trackpoint>\r\n", file);
@@ -128,6 +135,9 @@ void export_tcx(TTBIN_FILE *ttbin, FILE *file)
                 fputs(        "                    <Extensions>\r\n"
                               "                       <LX xmlns=\"http://www.garmin.com/xmlschemas/ActivityExtension/v2\">\r\n", file);
                 fprintf(file, "                           <AvgSpeed>%.5f</AvgSpeed>\r\n", lap_avg_speed);
+                if (lap_step_count)
+                    fprintf(file, "                           <Steps>%d</Steps>\r\n"
+                              "                           <AvgRunCadence>%d</AvgRunCadence>\r\n", lap_step_count, 30*lap_step_count/lap_time);
                 fputs(        "                       </LX>\r\n"
                               "                    </Extensions>\r\n", file);
                 fputs(        "                </Track>\r\n", file);
@@ -167,12 +177,14 @@ void export_tcx(TTBIN_FILE *ttbin, FILE *file)
             if (heart_rate_count > 0)
                 lap_avg_heart_rate = (total_heart_rate + (heart_rate_count >> 1)) / heart_rate_count;
             lap_max_heart_rate = max_heart_rate;
+            lap_step_count = total_step_count;
             gps_count = 0;
             heart_rate_count = 0;
             total_speed = 0;
             max_speed = 0;
             max_heart_rate = 0;
             total_heart_rate = 0;
+            total_step_count = 0;
             lap_state = 2;
             break;
         }
@@ -191,11 +203,15 @@ void export_tcx(TTBIN_FILE *ttbin, FILE *file)
             if (heart_rate_count > 0)
                 lap_avg_heart_rate = (total_heart_rate + (heart_rate_count >> 1)) / heart_rate_count;
             lap_max_heart_rate = max_heart_rate;
+            lap_step_count = total_step_count;
         }
 
         fputs(        "                    <Extensions>\r\n"
                       "                       <LX xmlns=\"http://www.garmin.com/xmlschemas/ActivityExtension/v2\">\r\n", file);
         fprintf(file, "                           <AvgSpeed>%.5f</AvgSpeed>\r\n", lap_avg_speed);
+        if (lap_step_count)
+            fprintf(file, "                           <Steps>%d</Steps>\r\n"
+                      "                           <AvgRunCadence>%d</AvgRunCadence>\r\n", lap_step_count, 30*lap_step_count/lap_time);
         fputs(        "                       </LX>\r\n"
                       "                    </Extensions>\r\n", file);
         fputs(        "                </Track>\r\n", file);


### PR DESCRIPTION
TCX format for running cadence is based on: http://www8.garmin.com/xmlschemas/ActivityExtensionv2.xsd

TomTom's cycles/second should be multiplied by 30, not 60, to obtain cadence in Garmin's units, because the Garmin footpod is only counting one foot.

The mysports.tomtom.com website seems to show steps/minute from the TTBIN file as well:
![image](http://i.snag.gy/XK6H8.jpg)