### PR TITLE
fixed issued parsing multiple laps

### DIFF
--- a/ttbincnv/ttbincnv.c
+++ b/ttbincnv/ttbincnv.c
@@ -30,6 +30,7 @@ void do_replace_lap_list(TTBIN_FILE *ttbin, const char *laps)
 
         token = strtok(NULL, seps);
     }
+    free(tlaps);
 
     replace_lap_list(ttbin, distances, count);
 }

--- a/ttbincnv/ttbincnv.c
+++ b/ttbincnv/ttbincnv.c
@@ -16,19 +16,19 @@ void do_replace_lap_list(TTBIN_FILE *ttbin, const char *laps)
     float distance = 0;
     float *distances = 0;
     unsigned count = 0;
+    char *tlaps;
+    char *token;
+    const char seps[] = " ,";
 
-    while (*laps)
+    tlaps = strdup(laps);
+    token = strtok(tlaps, seps);
+    while (token != NULL)
     {
-        /* find the first lap distance */
-        if (sscanf(laps, "%f", &distance) != 1)
-            return;
-
+        sscanf(token, "%f", &distance);
         distances = (float*)realloc(distances, (count + 1) * sizeof(float));
         distances[count++] = distance;
 
-        /* scan the next lap distance */
-        while (*laps && (*laps != ','))
-            ++laps;
+        token = strtok(NULL, seps);
     }
 
     replace_lap_list(ttbin, distances, count);

--- a/ttbinmod/ttbinmod.c
+++ b/ttbinmod/ttbinmod.c
@@ -36,6 +36,7 @@ void do_replace_lap_list(TTBIN_FILE *ttbin, const char *laps)
 
         token = strtok(NULL, seps);
     }
+    free(tlaps);
 
     replace_lap_list(ttbin, distances, count);
 }

--- a/ttbinmod/ttbinmod.c
+++ b/ttbinmod/ttbinmod.c
@@ -22,19 +22,19 @@ void do_replace_lap_list(TTBIN_FILE *ttbin, const char *laps)
     float distance = 0;
     float *distances = 0;
     unsigned count = 0;
+    char *tlaps;
+    char *token;
+    const char seps[] = " ,";
 
-    while (*laps)
+    tlaps = strdup(laps);
+    token = strtok(tlaps, seps);
+    while (token != NULL)
     {
-        /* find the first lap distance */
-        if (sscanf(laps, "%f", &distance) != 1)
-            return;
-
+        sscanf(token, "%f", &distance);
         distances = (float*)realloc(distances, (count + 1) * sizeof(float));
         distances[count++] = distance;
 
-        /* scan the next lap distance */
-        while (*laps && (*laps != ','))
-            ++laps;
+        token = strtok(NULL, seps);
     }
 
     replace_lap_list(ttbin, distances, count);


### PR DESCRIPTION
Parsing of the multiple laps option (e.g. using --laps="100,500,100,1000") wasn't working due to an off-by-one problem after the first comma. Switched to using strtok and added handling of the space character as well.