### PR TITLE
Inconsistent lap_heart_rate_count

### DIFF
--- a/ttbin/export_tcx.c
+++ b/ttbin/export_tcx.c
@@ -215,9 +215,9 @@ void export_tcx(TTBIN_FILE *ttbin, FILE *file)
             lap_distance = ttbin->total_distance - lap_start_distance;
             lap_max_speed = max_speed;
             lap_calories = ttbin->total_calories - lap_start_calories;
-            lap_heart_rate_count = heart_rate_count;
-            if (heart_rate_count > 0)
-                lap_avg_heart_rate = (total_heart_rate + (heart_rate_count >> 1)) / heart_rate_count;
+            lap_heart_rate_count = heart_rate_count - lap_start_heart_rate_count;;
+            if (lap_heart_rate_count > 0)
+                lap_avg_heart_rate = (total_heart_rate + (lap_heart_rate_count >> 1)) / lap_heart_rate_count;
             lap_max_heart_rate = max_heart_rate;
             lap_step_count = total_step_count;
         }


### PR DESCRIPTION
In #9, I fixed the issue with cumulative lap distance/calories/time. At the time, I didn't realize then that `lap_heart_rate_count` should **also** not be cumulative.

In ae98d942 you [fixed `lap_heart_rate_count` in the `TAG_LAP` handler](https://github.com/ryanbinns/ttwatch/commit/ae98d942#diff-7a7bc983af45c3393f3acd8e2da693d0R177), but it looks like you did *not* fix it in the end-of-file cleanup block. Here's a patch to do that.