### PR TITLE
Allow Treadmill export as TCX

### DIFF
--- a/ttbin/export_tcx.c
+++ b/ttbin/export_tcx.c
@@ -97,43 +97,54 @@ void export_tcx(TTBIN_FILE *ttbin, FILE *file)
             break;
 
         case TAG_TREADMILL:
-            /* this will happen if the activity is paused and then resumed */
-            if (record->treadmill.timestamp == 0)
-                break;
+        case TAG_GPS:
+            if (record->tag==TAG_TREADMILL) {
+                /* this will happen if the activity is paused and then resumed */
+                if (record->treadmill.timestamp == 0)
+                    break;
 
-            steps = record->treadmill.steps - steps_prev;
-            steps_prev = record->treadmill.steps;
+                steps = record->treadmill.steps - steps_prev;
+                steps_prev = record->treadmill.steps;
 
-            /* low-pass filter the coarse cadence values (1, 2, 3 steps/sec), with RC=20
-               based on: https://en.wikipedia.org/wiki/Low-pass_filter#Simple_infinite_impulse_response_filter */
-            {
-                float dt = smooth_cadence_count == 0 ? 1.0f : record->treadmill.timestamp - smooth_cadence_lt;
-                float rc = smooth_cadence_count < 20 ? (float)smooth_cadence_count : 20.0f;
-                float alpha = dt / (rc + dt);
-                int coarse_cadence = 30*(int)steps;
-                smooth_cadence += alpha * (coarse_cadence - smooth_cadence);
-                smooth_cadence_count++;
-                smooth_cadence_lt = record->treadmill.timestamp;
+                /* low-pass filter the coarse cadence values (1, 2, 3 steps/sec), with RC=20
+                   based on: https://en.wikipedia.org/wiki/Low-pass_filter#Simple_infinite_impulse_response_filter */
+                {
+                    float dt = smooth_cadence_count == 0 ? 1.0f : record->treadmill.timestamp - smooth_cadence_lt;
+                    float rc = smooth_cadence_count < 20 ? (float)smooth_cadence_count : 20.0f;
+                    float alpha = dt / (rc + dt);
+                    int coarse_cadence = 30*(int)steps;
+                    smooth_cadence += alpha * (coarse_cadence - smooth_cadence);
+                    smooth_cadence_count++;
+                    smooth_cadence_lt = record->treadmill.timestamp;
+                }
+
+                total_step_count += steps;
+            } else { /* TAG_GPS only */
+                /* this will happen if the activity is paused and then resumed, or if the GPS signal is lost  */
+                if ((record->gps.timestamp == 0) || ((record->gps.latitude == 0) && (record->gps.longitude == 0)))
+                    break;
+
+                if (record->gps.instant_speed > max_speed)
+                    max_speed = record->gps.instant_speed;
+                total_speed += record->gps.instant_speed;
+
+                /* low-pass filter the coarse cadence values (1, 2, 3 steps/sec), with RC=20
+                   based on: https://en.wikipedia.org/wiki/Low-pass_filter#Simple_infinite_impulse_response_filter */
+                if (ttbin->activity==ACTIVITY_RUNNING)
+                {
+                    float dt = smooth_cadence_count == 0 ? 1.0f : record->gps.timestamp - smooth_cadence_lt;
+                    float rc = smooth_cadence_count < 20 ? (float)smooth_cadence_count : 20.0f;
+                    float alpha = dt / (rc + dt);
+                    int coarse_cadence = 30*(int)record->gps.cycles;
+                    smooth_cadence += alpha * (coarse_cadence - smooth_cadence);
+                    smooth_cadence_count++;
+                    smooth_cadence_lt = record->gps.timestamp;
+                }
+                if (ttbin->activity==ACTIVITY_RUNNING)
+                    total_step_count += record->gps.cycles;
             }
 
-            total_step_count += steps;
-            goto motion_common;
-
-        case TAG_GPS:
-            /* this will happen if the activity is paused and then resumed, or if the GPS signal is lost  */
-            if ((record->gps.timestamp == 0) || ((record->gps.latitude == 0) && (record->gps.longitude == 0)))
-                break;
-
-            if (record->gps.instant_speed > max_speed)
-                max_speed = record->gps.instant_speed;
-            total_speed += record->gps.instant_speed;
-
-            /* low-pass filter the coarse cadence values (1, 2, 3 steps/sec), with RC=20
-            if (ttbin->activity==ACTIVITY_RUNNING)
-                total_step_count += record->gps.cycles;
-            goto motion_common;
-
-        motion_common:
+            /* code common to both TAG_GPS and TAG_TREADMILL */
             ++move_count;
 
             if (lap_state == 0 && insert_pause)

--- a/ttbin/export_tcx.c
+++ b/ttbin/export_tcx.c
@@ -16,7 +16,7 @@ void export_tcx(TTBIN_FILE *ttbin, FILE *file)
     uint32_t total_heart_rate = 0;
     uint32_t max_heart_rate = 0;
     uint32_t heart_rate_count = 0;
-    uint32_t gps_count = 0;
+    uint32_t move_count = 0;
     uint32_t total_step_count = 0;
     unsigned heart_rate;
     int lap_state;
@@ -33,8 +33,19 @@ void export_tcx(TTBIN_FILE *ttbin, FILE *file)
     unsigned lap_step_count;
     float cadence_avg = 0.0f;
     const char *trigger_method = "Manual";
+    double distance_factor = 1;
+    uint32_t steps, steps_prev = 0;
 
-    if (!ttbin->gps_records.count)
+    if (ttbin->activity == ACTIVITY_TREADMILL) {
+        for (record = ttbin->last; record; record = record->prev)
+        {
+            if ((record->tag == TAG_TREADMILL) && record->treadmill.distance)
+            {
+                distance_factor = ttbin->total_distance / record->treadmill.distance;
+                break;
+            }
+        }
+    } else if (!ttbin->gps_records.count)
         return;
 
     fputs("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n"
@@ -51,7 +62,7 @@ void export_tcx(TTBIN_FILE *ttbin, FILE *file)
     case ACTIVITY_RUNNING:   fputs("Running", file);   break;
     case ACTIVITY_CYCLING:   fputs("Cycling", file);   break;
     case ACTIVITY_SWIMMING:  fputs("Pool Swim", file); break;
-    case ACTIVITY_TREADMILL: fputs("Treadmill", file); break;
+    case ACTIVITY_TREADMILL: fputs("Running", file);   break; /* per Garmin spec, not "Treadmill" */
     case ACTIVITY_FREESTYLE: fputs("Freestyle", file); break;
     default:                 fputs("Unknown", file);   break;
     }
@@ -85,6 +96,29 @@ void export_tcx(TTBIN_FILE *ttbin, FILE *file)
                 insert_pause = 1;
             break;
 
+        case TAG_TREADMILL:
+            /* this will happen if the activity is paused and then resumed */
+            if (record->treadmill.timestamp == 0)
+                break;
+
+            steps = record->treadmill.steps - steps_prev;
+            steps_prev = record->treadmill.steps;
+
+            /* low-pass filter the coarse cadence values (1, 2, 3 steps/sec), with RC=20
+               based on: https://en.wikipedia.org/wiki/Low-pass_filter#Simple_infinite_impulse_response_filter */
+            {
+                float dt = smooth_cadence_count == 0 ? 1.0f : record->treadmill.timestamp - smooth_cadence_lt;
+                float rc = smooth_cadence_count < 20 ? (float)smooth_cadence_count : 20.0f;
+                float alpha = dt / (rc + dt);
+                int coarse_cadence = 30*(int)steps;
+                smooth_cadence += alpha * (coarse_cadence - smooth_cadence);
+                smooth_cadence_count++;
+                smooth_cadence_lt = record->treadmill.timestamp;
+            }
+
+            total_step_count += steps;
+            goto motion_common;
+
         case TAG_GPS:
             /* this will happen if the activity is paused and then resumed, or if the GPS signal is lost  */
             if ((record->gps.timestamp == 0) || ((record->gps.latitude == 0) && (record->gps.longitude == 0)))
@@ -93,7 +127,14 @@ void export_tcx(TTBIN_FILE *ttbin, FILE *file)
             if (record->gps.instant_speed > max_speed)
                 max_speed = record->gps.instant_speed;
             total_speed += record->gps.instant_speed;
-            ++gps_count;
+
+            /* low-pass filter the coarse cadence values (1, 2, 3 steps/sec), with RC=20
+            if (ttbin->activity==ACTIVITY_RUNNING)
+                total_step_count += record->gps.cycles;
+            goto motion_common;
+
+        motion_common:
+            ++move_count;
 
             if (lap_state == 0 && insert_pause)
             {
@@ -111,33 +152,43 @@ void export_tcx(TTBIN_FILE *ttbin, FILE *file)
                 lap_state = 0;
             }
 
-            strftime(timestr, sizeof(timestr), "%FT%X.000Z", gmtime(&record->gps.timestamp));
+            if (record->tag==TAG_GPS)
+                strftime(timestr, sizeof(timestr), "%FT%X.000Z", gmtime(&record->gps.timestamp));
+            else if (record->tag==TAG_TREADMILL)
+                strftime(timestr, sizeof(timestr), "%FT%X.000Z", gmtime(&record->treadmill.timestamp));
+
             fputs(        "                    <Trackpoint>\r\n", file);
             fprintf(file, "                        <Time>%s</Time>\r\n", timestr);
-            fputs(        "                        <Position>\r\n", file);
-            fprintf(file, "                            <LatitudeDegrees>%.7f</LatitudeDegrees>\r\n", record->gps.latitude);
-            fprintf(file, "                            <LongitudeDegrees>%.7f</LongitudeDegrees>\r\n", record->gps.longitude);
-            fputs(        "                        </Position>\r\n", file);
-            if (!isnan(record->gps.elevation))
-                fprintf(file, "                        <AltitudeMeters>%.0f</AltitudeMeters>\r\n", record->gps.elevation);
-            fprintf(file, "                        <DistanceMeters>%.5f</DistanceMeters>\r\n", record->gps.cum_distance);
+            if (record->tag==TAG_GPS) {
+                fputs(        "                        <Position>\r\n", file);
+                fprintf(file, "                            <LatitudeDegrees>%.7f</LatitudeDegrees>\r\n", record->gps.latitude);
+                fprintf(file, "                            <LongitudeDegrees>%.7f</LongitudeDegrees>\r\n", record->gps.longitude);
+                fputs(        "                        </Position>\r\n", file);
+                if (!isnan(record->gps.elevation))
+                    fprintf(file, "                        <AltitudeMeters>%.0f</AltitudeMeters>\r\n", record->gps.elevation);
+            }
+
+            if (record->tag==TAG_GPS)
+                fprintf(file, "                        <DistanceMeters>%.5f</DistanceMeters>\r\n", record->gps.cum_distance);
+            else if (record->tag==TAG_TREADMILL)
+                fprintf(file, "                        <DistanceMeters>%.5f</DistanceMeters>\r\n", record->treadmill.distance * distance_factor);
+
             if (heart_rate > 0)
             {
                 fputs(        "                        <HeartRateBpm>\r\n", file);
                 fprintf(file, "                            <Value>%d</Value>\r\n", heart_rate);
                 fputs(        "                        </HeartRateBpm>\r\n", file);
             }
+
             fputs(        "                        <Extensions>\r\n"
                           "                            <TPX xmlns=\"http://www.garmin.com/xmlschemas/ActivityExtension/v2\">\r\n", file);
-            fprintf(file, "                                <Speed>%.2f</Speed>\r\n", record->gps.instant_speed);
-            if (ttbin->activity==ACTIVITY_RUNNING)
-            {
+            if (record->tag==TAG_GPS)
+                fprintf(file, "                                <Speed>%.2f</Speed>\r\n", record->gps.instant_speed);
+            if (ttbin->activity==ACTIVITY_RUNNING || ttbin->activity==ACTIVITY_TREADMILL)
                 /* use an exponential moving average to smooth cadence data */
                 if ((int)record->gps.cycles <= 4) // max 4 * 60 = 240 spm
                     cadence_avg = (0.05 * 30 * (int)record->gps.cycles) + (1.0 - 0.05) * cadence_avg;
                 fprintf(file, "                                <RunCadence>%d</RunCadence>\r\n", (int)cadence_avg);
-                total_step_count += record->gps.cycles;
-            }
             fputs(        "                            </TPX>\r\n"
                           "                        </Extensions>\r\n"
                           "                    </Trackpoint>\r\n", file);
@@ -155,7 +206,8 @@ void export_tcx(TTBIN_FILE *ttbin, FILE *file)
                 fprintf(file, "                <TriggerMethod>%s</TriggerMethod>\r\n", trigger_method);
                 fprintf(file, "                <TotalTimeSeconds>%d</TotalTimeSeconds>\r\n", lap_time);
                 fprintf(file, "                <DistanceMeters>%.2f</DistanceMeters>\r\n", lap_distance);
-                fprintf(file, "                <MaximumSpeed>%.2f</MaximumSpeed>\r\n", lap_max_speed);
+                if (record->tag==TAG_GPS)
+                    fprintf(file, "                <MaximumSpeed>%.2f</MaximumSpeed>\r\n", lap_max_speed);
                 fprintf(file, "                <Calories>%d</Calories>\r\n", lap_calories);
                 if (heart_rate_count)
                 {
@@ -180,9 +232,14 @@ void export_tcx(TTBIN_FILE *ttbin, FILE *file)
             heart_rate = record->heart_rate.heart_rate;
             break;
         case TAG_LAP:
-            lap_avg_speed = total_speed / gps_count;
             lap_time = record->lap.total_time - lap_start_time;
-            lap_distance = record->lap.total_distance - lap_start_distance;
+            if (ttbin->activity == ACTIVITY_TREADMILL) {
+                lap_distance = distance_factor * (double)(record->lap.total_distance - lap_start_distance);
+                lap_avg_speed = lap_distance / move_count;
+            } else {
+                lap_distance = record->lap.total_distance - lap_start_distance;
+                lap_avg_speed = total_speed / move_count;
+            }
             lap_max_speed = max_speed;
             lap_calories = record->lap.total_calories - lap_start_calories;
             lap_heart_rate_count = heart_rate_count - lap_start_heart_rate_count;;
@@ -190,7 +247,7 @@ void export_tcx(TTBIN_FILE *ttbin, FILE *file)
                 lap_avg_heart_rate = (total_heart_rate + (lap_heart_rate_count >> 1)) / lap_heart_rate_count;
             lap_max_heart_rate = max_heart_rate;
             lap_step_count = total_step_count;
-            gps_count = 0;
+            move_count = 0;
             heart_rate_count = 0;
             total_speed = 0;
             max_speed = 0;
@@ -210,9 +267,12 @@ void export_tcx(TTBIN_FILE *ttbin, FILE *file)
     {
         if (!lap_state)
         {
-            lap_avg_speed = total_speed / gps_count;
             lap_time = ttbin->duration - lap_start_time;
             lap_distance = ttbin->total_distance - lap_start_distance;
+            if (ttbin->activity == ACTIVITY_TREADMILL)
+                lap_avg_speed = lap_distance / move_count;
+            else
+                lap_avg_speed = total_speed / move_count;
             lap_max_speed = max_speed;
             lap_calories = ttbin->total_calories - lap_start_calories;
             lap_heart_rate_count = heart_rate_count;
@@ -234,7 +294,8 @@ void export_tcx(TTBIN_FILE *ttbin, FILE *file)
         fprintf(file, "                <TriggerMethod>%s</TriggerMethod>\r\n", trigger_method);
         fprintf(file, "                <TotalTimeSeconds>%d</TotalTimeSeconds>\r\n", lap_time);
         fprintf(file, "                <DistanceMeters>%.2f</DistanceMeters>\r\n", lap_distance);
-        fprintf(file, "                <MaximumSpeed>%.2f</MaximumSpeed>\r\n", lap_max_speed);
+        if (ttbin->gps_records.count)
+            fprintf(file, "                <MaximumSpeed>%.2f</MaximumSpeed>\r\n", lap_max_speed);
         fprintf(file, "                <Calories>%d</Calories>\r\n", lap_calories);
         if (heart_rate_count)
         {

--- a/ttbin/ttbin.c
+++ b/ttbin/ttbin.c
@@ -19,12 +19,12 @@
 /*****************************************************************************/
 
 const OFFLINE_FORMAT OFFLINE_FORMATS[OFFLINE_FORMAT_COUNT] = {
-    { OFFLINE_FORMAT_CSV, "csv", 0, export_csv },
-    { OFFLINE_FORMAT_FIT, "fit", 1, 0          },
-    { OFFLINE_FORMAT_GPX, "gpx", 1, export_gpx },
-    { OFFLINE_FORMAT_KML, "kml", 1, export_kml },
-    { OFFLINE_FORMAT_PWX, "pwx", 1, 0          },
-    { OFFLINE_FORMAT_TCX, "tcx", 1, export_tcx },
+    { OFFLINE_FORMAT_CSV, "csv", 1, 1, 1, export_csv },
+    { OFFLINE_FORMAT_FIT, "fit", 1, 0, 0, 0          },
+    { OFFLINE_FORMAT_GPX, "gpx", 1, 0, 0, export_gpx },
+    { OFFLINE_FORMAT_KML, "kml", 1, 0, 0, export_kml },
+    { OFFLINE_FORMAT_PWX, "pwx", 1, 0, 0, 0          },
+    { OFFLINE_FORMAT_TCX, "tcx", 1, 1, 0, export_tcx },
 };
 
 /*****************************************************************************/
@@ -960,7 +960,9 @@ uint32_t export_formats(TTBIN_FILE *ttbin, uint32_t formats)
     {
         if ((formats & OFFLINE_FORMATS[i].mask) && OFFLINE_FORMATS[i].producer)
         {
-            if (!OFFLINE_FORMATS[i].requires_gps || ttbin->gps_records.count)
+            if ((OFFLINE_FORMATS[i].gps_ok && ttbin->gps_records.count)
+                || (OFFLINE_FORMATS[i].treadmill_ok && ttbin->activity==ACTIVITY_TREADMILL)
+                || (OFFLINE_FORMATS[i].pool_swim_ok && ttbin->activity==ACTIVITY_SWIMMING))
             {
                 f = fopen(create_filename(ttbin, OFFLINE_FORMATS[i].name), "w");
                 if (f)

--- a/ttbin/ttbin.h
+++ b/ttbin/ttbin.h
@@ -317,7 +317,9 @@ typedef struct
 {
     uint32_t mask;
     const char *name;
-    int requires_gps;
+    int gps_ok;
+    int treadmill_ok;
+    int pool_swim_ok;
     void (*producer)(TTBIN_FILE* ttbin, FILE *file);
 } OFFLINE_FORMAT;
 

--- a/ttbincnv/ttbincnv.c
+++ b/ttbincnv/ttbincnv.c
@@ -205,7 +205,9 @@ int main(int argc, char *argv[])
     {
         if ((formats & OFFLINE_FORMATS[i].mask) && OFFLINE_FORMATS[i].producer)
         {
-            if (!OFFLINE_FORMATS[i].requires_gps || ttbin->gps_records.count)
+            if ((OFFLINE_FORMATS[i].gps_ok && ttbin->gps_records.count)
+                || (OFFLINE_FORMATS[i].treadmill_ok && ttbin->activity==ACTIVITY_TREADMILL)
+                || (OFFLINE_FORMATS[i].pool_swim_ok && ttbin->activity==ACTIVITY_SWIMMING))
             {
                 FILE *output_file = stdout;
                 if (!pipe_mode)


### PR DESCRIPTION
This has been slightly bugging me for a while, because I couldn't auto-export Treadmill activities in a format that Strava and Garmin Connect will understand.

Basically, I tried to reuse the "outdoor" GPS-based logic for TCX export as much as possible, with just a couple conditional checks for Treadmill-specific stuff (no coordinates and no instantaneous speed).

I also changed the `OFFLINE_FORMAT` structure to distinguish 3 different kinds of activities that each format could potentially support: `gps_ok`, `treadmill_ok`, `pool_swim_ok`.