### PR TITLE
Add initial support for Spark/Runner2 models

### DIFF
--- a/libttwatch/libttwatch.h
+++ b/libttwatch/libttwatch.h
@@ -27,6 +27,8 @@ typedef struct
     uint32_t    ble_version;
     const char  serial_number[64];
 
+    uint16_t    usb_product_id;
+
     uint32_t    current_file;
 
     char       *preferences_file;


### PR DESCRIPTION
Hi Ryan, I've been working on Spark/Runner2 support for ttwatch. Looking at USB traces of the original TomTom software it appears, that the new models use a fixed 256 byte packet size for usb communication (filled with 0s). To make ttwatch compatible with both, the Multisport/Runner and Spark/Runner2 models, the used packet size therefore has to be adjusted dependent on the usb product id, which I added accordingly.

This works for my Runner2 model (tested getting activities and updating QuickGPS), but has yet to be tested for the Multisport/Runner models.

Also there doesn't seem to be a separate BLE firmware for these models (at least the xml retrieved from the TomTom server didn't contain a BLE tag). Therefore, I added a check to only search for a BLE firmware when a Multisport/Runner model is connected. This made the latest firmware update work for my Runner2.