### PR TITLE
Fixed --list-history for Spark and Runner2

### DIFF
--- a/libttwatch/libttwatch.h
+++ b/libttwatch/libttwatch.h
@@ -120,24 +120,27 @@ typedef struct __attribute__((packed))
     uint32_t second;
     union
     {
-        uint32_t _unk3[2];
-        uint32_t duration;
-        float    distance;
-        uint32_t calories;
-        uint32_t file_id;           /* does not contain valid data for swim entries */
-        uint32_t swolf;             /* only exists for swim entries */
-        uint32_t strokes_per_lap;   /* only exists for swim entries */
-    } multisport;
-    union
-    {
-        uint8_t _unk3[11];
-        uint32_t duration;
-        float    distance;
-        uint32_t calories;
-        uint32_t file_id;           /* does not contain valid data for swim entries */
-        uint32_t swolf;             /* only exists for swim entries */
-        uint32_t strokes_per_lap;   /* only exists for swim entries */
-    } spark;
+        struct  __attribute__((packed))
+        {
+            uint32_t _unk3[2];
+            uint32_t duration;
+            float    distance;
+            uint32_t calories;
+            uint32_t file_id;           /* does not contain valid data for swim entries */
+            uint32_t swolf;             /* only exists for swim entries */
+            uint32_t strokes_per_lap;   /* only exists for swim entries */
+        } multisport;
+        struct __attribute__((packed))
+        {
+            uint8_t _unk3[11];
+            uint32_t duration;
+            float    distance;
+            uint32_t calories;
+            uint32_t file_id;           /* does not contain valid data for swim entries */
+            uint32_t swolf;             /* only exists for swim entries */
+            uint32_t strokes_per_lap;   /* only exists for swim entries */
+        } spark;
+    };
 } TTWATCH_HISTORY_ENTRY;
 
 /*****************************************************************************/

--- a/ttwatch/ttwatch.c
+++ b/ttwatch/ttwatch.c
@@ -1258,14 +1258,14 @@ static void do_list_history_callback(TTWATCH_ACTIVITY activity, int index, const
         entry->year, entry->month, entry->day, entry->hour, entry->minute, entry->second);
     if (d->watch->usb_product_id == TOMTOM_MULTISPORT_PRODUCT_ID)
     {
-        write_log(0, ", %4ds, %8.2fm, %4d calories", index + 1,
+        write_log(0, ", %4ds, %8.2fm, %4d calories", index,
             entry->multisport.duration, entry->multisport.distance, entry->multisport.calories);
         if (entry->activity == TTWATCH_Swimming)
             write_log(0, ", %d swolf, %d spl", entry->multisport.swolf, entry->multisport.strokes_per_lap);
     }
     else
     {
-        write_log(0, ", %4ds, %8.2fm, %4d calories", index + 1,
+        write_log(0, ", %4ds, %8.2fm, %4d calories", index,
             entry->spark.duration, entry->spark.distance, entry->spark.calories);
         if (entry->activity == TTWATCH_Swimming)
             write_log(0, ", %d swolf, %d spl", entry->spark.swolf, entry->spark.strokes_per_lap);

--- a/ttwatch/ttwatch.c
+++ b/ttwatch/ttwatch.c
@@ -1258,14 +1258,14 @@ static void do_list_history_callback(TTWATCH_ACTIVITY activity, int index, const
         entry->year, entry->month, entry->day, entry->hour, entry->minute, entry->second);
     if (d->watch->usb_product_id == TOMTOM_MULTISPORT_PRODUCT_ID)
     {
-        write_log(0, ", %4ds, %8.2fm, %4d calories", index,
+        write_log(0, ", %4ds, %8.2fm, %4d calories",
             entry->multisport.duration, entry->multisport.distance, entry->multisport.calories);
         if (entry->activity == TTWATCH_Swimming)
             write_log(0, ", %d swolf, %d spl", entry->multisport.swolf, entry->multisport.strokes_per_lap);
     }
     else
     {
-        write_log(0, ", %4ds, %8.2fm, %4d calories", index,
+        write_log(0, ", %4ds, %8.2fm, %4d calories",
             entry->spark.duration, entry->spark.distance, entry->spark.calories);
         if (entry->activity == TTWATCH_Swimming)
             write_log(0, ", %d swolf, %d spl", entry->spark.swolf, entry->spark.strokes_per_lap);


### PR DESCRIPTION
Made the code changes as per https://github.com/ryanbinns/ttwatch/issues/49#issuecomment-169320951

Although most arguments work, the "duration" doesn't yet:

```
Running:
1: 2016/01/04 12:25:58,    0s,  5145.58m, 1620 calories
2: 2016/01/04 12:58:58,    1s,  1011.35m,  304 calories
3: 2016/01/06 12:21:37,    2s,  6693.93m, 2198 calories
```

Perhaps the "extra 3 bytes" are more accuracy for duration? I'll continue to check.