### PR TITLE
workaround for incorrect UTC time on watch

### DIFF
--- a/ttwatch/ttwatch.c
+++ b/ttwatch/ttwatch.c
@@ -312,8 +312,23 @@ void do_set_time(TTWATCH *watch)
     time_t utc_time = time(NULL);
 
     localtime_r(&utc_time, &tm_local);
-
     int32_t offset = tm_local.tm_gmtoff;
+
+    time_t watch_utc_time;
+    if (ttwatch_get_watch_time(watch, &watch_utc_time) != TTWATCH_NoError)
+    {
+        write_log(1, "Unable to get watch time\n");
+        return;
+    }
+    /* if the UTC time of the watch is severely skewed, adjust the
+       offset so that the local time still shows up correctly, and
+       warn the user */
+    if (abs(watch_utc_time - utc_time) > 600)
+    {
+        write_log(1, "Watch has wrong UTC time. Use GPS to correct this.\n");
+        offset += utc_time - watch_utc_time;
+    }
+
     if ((ttwatch_set_manifest_entry(watch, TT_MANIFEST_ENTRY_UTC_OFFSET, (uint32_t*)&offset) != TTWATCH_NoError) ||
         (ttwatch_write_manifest(watch) != TTWATCH_NoError))
     {


### PR DESCRIPTION
This patch slightly alters the behavior of `ttwatch --set-time`. If the UTC
time of the watch is severely skewed, as with a brand new or factory reset
watch, it adjusts the UTC time offset to make the correct local time show up
on the watch, and warns the user that they should use the GPS to set the
correct UTC time on the watch.

The watch firmware appears to do the same thing when setting the time on
new/reset watch where the GPS hasn't yet been initalized.

This should help new users avoid the confusing issue where the time is wrong
on a new watch, even after running `--set-time` (as in #73 and #58).