### PR TITLE
Fixed a serious flaw in the string replace function

### DIFF
--- a/src/ttwatch.c
+++ b/src/ttwatch.c
@@ -262,8 +262,10 @@ char *replace(char *str, const char *old, const char *new)
     char *ptr = strstr(str, old);
     while (ptr)
     {
-        size_t offset = ptr - str;
-        char *new_str = (char*)malloc((int)strlen(str) + correct + 1);
+        const size_t offset = ptr - str;
+        const size_t new_str_len = (int)strlen(str) + correct + 1;
+        char *new_str = (char*)malloc(new_str_len);
+        memset(new_str, 0, new_str_len);
 
         strncpy(new_str, str, offset);
         strcat(new_str, new);


### PR DESCRIPTION
A buffer for the new string is allocated but not zero-filled. This causes undefined behavior. In my case it caused application crashes since strcat will concat the string to the end of the lhs. The end is obviously defined by a \0 character. In my case the first \0 was found outside the allocated buffer.