### PR TITLE
Implement exporting cycling cadence data from compatible bluetooth sensors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,7 @@ set(LIBTTWATCH_SRC src/libttwatch.cpp src/libttwatch_cpp.cpp)
 add_library(libttwatch STATIC ${LIBTTWATCH_SRC})
 set_target_properties(libttwatch PROPERTIES OUTPUT_NAME ttwatch)
 
-set(TTBIN_SRC src/export_csv.c src/export_gpx.c src/export_kml.c src/export_tcx.c src/ttbin.c)
+set(TTBIN_SRC src/export_csv.c src/export_gpx.c src/export_kml.c src/export_tcx.c src/ttbin.c src/cycling_cadence.c)
 add_library(libttbin STATIC ${TTBIN_SRC})
 target_link_libraries(libttbin ${CURL_LIBRARIES})
 set_target_properties(libttbin PROPERTIES OUTPUT_NAME ttbin)
@@ -72,7 +72,7 @@ add_custom_command(OUTPUT manifest_definitions_0001082e.h
 add_custom_command(OUTPUT manifest_definitions_0001031b.h
   DEPENDS ${MANIFEST_DIR}/manifest_0001031b.txt ${MANIFEST_DIR}/make_manifest.pl
   COMMAND ${PERL_EXECUTABLE} ${MANIFEST_DIR}/make_manifest.pl < ${MANIFEST_DIR}/manifest_0001031b.txt > manifest_definitions_0001031b.h)
-  
+
 set(TTWATCH_SRC src/ttwatch.c src/log.c src/options.c src/json.c src/download.c src/firmware.c src/misc.c src/get_activities.c src/update_gps.c src/set_time.c)
 add_executable(ttwatch ${TTWATCH_SRC})
 target_link_libraries(ttwatch libttwatch libttbin ${LIBUSB_1_LIBRARIES} ${OPENSSL_LIBRARIES})

--- a/include/cycling_cadence.h
+++ b/include/cycling_cadence.h
@@ -1,0 +1,27 @@
+#ifndef CYCLING_CADENCE_H_INCLUDED
+#define CYCLING_CADENCE_H_INCLUDED
+
+#include "ttbin.h"
+#include <stdbool.h>
+
+typedef struct
+{
+    uint32_t wheel_size;
+    uint16_t crank_rev_prev;
+    uint16_t crank_rev_time_prev; // Time in ms
+    uint16_t wheel_rev_prev;
+    uint16_t wheel_rev_time_prev; // Time in ms
+    uint8_t  cadence_watchdog;
+    uint8_t  wheel_speed_watchdog;
+    unsigned cycling_cadence;     // Cadence in rpm
+    float wheel_speed;            // Wheel speed in m/s
+    bool cadence_available;
+    bool wheel_speed_available;
+} CyclingCadenceData;
+
+CyclingCadenceData cc_initialize(void);
+void cc_set_wheel_size(CyclingCadenceData* data, WHEEL_SIZE_RECORD* record);
+void cc_sensor_packet(CyclingCadenceData* data, CYCLING_CADENCE_RECORD* record);
+void cc_gps_packet_tick(CyclingCadenceData* data);
+
+#endif // CYCLING_CADENCE_H_INCLUDED

--- a/src/cycling_cadence.c
+++ b/src/cycling_cadence.c
@@ -1,0 +1,108 @@
+#include "cycling_cadence.h"
+
+static uint32_t handle_overflow(uint16_t overflowable, uint16_t previous_value)
+{
+    if (overflowable < previous_value)
+        return (uint32_t)overflowable + 0x0000FFFF;
+    return overflowable;
+}
+
+static float calculate_wheel_speed(CyclingCadenceData* data, CYCLING_CADENCE_RECORD* record)
+{
+    uint32_t wheel_rev_prev = data->wheel_rev_prev;
+    uint32_t wheel_rev = handle_overflow(record->wheel_revolutions, wheel_rev_prev);
+
+    uint32_t wheel_rev_time_prev = data->wheel_rev_time_prev;
+    uint32_t wheel_rev_time = handle_overflow(record->wheel_revolutions_time, wheel_rev_time_prev);
+
+    float result = 0.001 *
+        (1000 * data->wheel_size * (wheel_rev - wheel_rev_prev) /
+            (wheel_rev_time - wheel_rev_time_prev)); //mm/s
+
+    if (result > 35) //35 m/s = 126 km/h
+        result = 0;
+    return result;
+}
+
+static unsigned calculate_cadence(CyclingCadenceData* data, CYCLING_CADENCE_RECORD* record)
+{
+    uint32_t crank_rev_prev = data->crank_rev_prev;
+    uint32_t crank_rev = handle_overflow(record->crank_revolutions, crank_rev_prev);
+
+    uint32_t crank_rev_time_prev = data->crank_rev_time_prev;
+    uint32_t crank_rev_time = handle_overflow(record->crank_revolutions_time, crank_rev_time_prev);
+
+    unsigned result = 60000L * (crank_rev - crank_rev_prev) /
+            (crank_rev_time - crank_rev_time_prev);
+
+    if (result > 200)
+        result = 0; /* bad_data */
+    return result;
+}
+
+CyclingCadenceData cc_initialize(void)
+{
+    CyclingCadenceData result = {
+        0,      //uint32_t wheel_size;
+        0,      //uint16_t crank_rev_prev;
+        0,      //uint16_t crank_rev_time_prev; // Time in ms
+        0,      //uint16_t wheel_rev_prev;
+        0,      //uint16_t wheel_rev_time_prev; // Time in ms
+        0,      //uint8_t  cadence_watchdog;
+        0,      //uint8_t  wheel_speed_watchdog;
+        0,      //unsigned cycling_cadence;     // Cadence in rpm
+        0.,     //float wheel_speed;            // Wheel speed in m/s
+        false,  //bool cadence_available;
+        false,   //bool wheel_speed_available;
+    };
+
+    return result;
+}
+
+void cc_set_wheel_size(CyclingCadenceData* data, WHEEL_SIZE_RECORD* record)
+{
+    data->wheel_size = record->wheel_size;
+}
+
+void cc_sensor_packet(CyclingCadenceData* data, CYCLING_CADENCE_RECORD* record)
+{
+    if (data->crank_rev_prev != record->crank_revolutions)
+    {
+        if (data->cadence_available)
+            data->cycling_cadence = calculate_cadence(data, record);
+        else
+            data->cadence_available = true;
+        data->crank_rev_prev      = record->crank_revolutions;
+        data->crank_rev_time_prev = record->crank_revolutions_time;
+        data->cadence_watchdog = 0;
+    }
+
+    if (data->wheel_rev_prev != record->wheel_revolutions && data->wheel_size > 0)
+    {
+        if (data->wheel_speed_available)
+            data->wheel_speed = calculate_wheel_speed(data, record);
+        else
+            data->wheel_speed_available = true;
+        data->wheel_rev_prev      = record->wheel_revolutions;
+        data->wheel_rev_time_prev = record->wheel_revolutions_time;
+        data->wheel_speed_watchdog = 0;
+    }
+}
+
+void cc_gps_packet_tick(CyclingCadenceData* data)
+{
+    /* clear cadence if no new data for 5 watchdog ticks*/
+    if (data->cadence_watchdog++ > 3)
+    {
+        data->cadence_watchdog = 0;
+        data->cycling_cadence = 0;
+    }
+
+    if (data->wheel_speed_watchdog++ > 3)
+    {
+        data->wheel_speed_watchdog = 0;
+        data->wheel_speed = 0;
+    }
+}
+
+

--- a/src/firmware.c
+++ b/src/firmware.c
@@ -108,7 +108,6 @@ int do_update_firmware(TTWATCH *watch, int force)
     uint32_t latest_ble_version;
     FIRMWARE_FILE *firmware_files = 0;
     int file_count = 0;
-    int i;
     char *ptr, *fw_url;
     char *serial = 0;
     char *fw_config_url = 0;


### PR DESCRIPTION
Tested to work with runner2 & Tomtom - 9UJ0.001.01 speed&cadence sensor
Both GPX and TCX files are recognized by strava.

No cadence points smoothing/filtering for the moment, it seems to work fine as-is.

Wheel speed does not work for me: ttbin files do not seem to include the wheel_size packet, maybe it needs to be added artificially (but out of the scope of this pull request)

Fixes #55 