### PR TITLE
Use calloc instead of malloc&memset

### DIFF
--- a/src/libttwatch.cpp
+++ b/src/libttwatch.cpp
@@ -364,8 +364,7 @@ int ttwatch_open_device(libusb_device *device, const char *serial_or_name, TTWAT
         return TTWATCH_UnableToOpenDevice;
     }
 
-    *watch = (TTWATCH*)malloc(sizeof(TTWATCH));
-    memset(*watch, 0, sizeof(TTWATCH));
+    *watch = (TTWATCH*)calloc(1, sizeof(TTWATCH));
     (*watch)->device = handle;
     (*watch)->usb_product_id = desc.idProduct;
 

--- a/src/misc.c
+++ b/src/misc.c
@@ -25,8 +25,7 @@ char *replace(char *str, const char *old, const char *newstr)
     {
         size_t offset = ptr - str;
         size_t new_str_len = strlen(str) + correct + 1;
-        char *new_str = (char*)malloc(new_str_len);
-        memset(new_str, 0, new_str_len);
+        char *new_str = (char*)calloc(1, new_str_len);
 
         strncpy(new_str, str, offset);
         strcat(new_str, newstr);

--- a/src/options.c
+++ b/src/options.c
@@ -199,16 +199,14 @@ void load_conf_file(const char *filename, OPTIONS *options, ConfLoadType load_ty
 /*****************************************************************************/
 OPTIONS *alloc_options()
 {
-    OPTIONS *o = malloc(sizeof(OPTIONS));
-    memset(o, 0, sizeof(OPTIONS));
+    OPTIONS *o = calloc(1, sizeof(OPTIONS));
     return o;
 }
 
 /*****************************************************************************/
 OPTIONS *copy_options(const OPTIONS *o)
 {
-    OPTIONS *op = malloc(sizeof(OPTIONS));
-    memcpy(op, o, sizeof(OPTIONS));
+    OPTIONS *op = alloc_options();
 
 #define COPY_STRING(n) if (o->n) op->n = strdup(o->n)
 

--- a/src/ttbin.c
+++ b/src/ttbin.c
@@ -325,8 +325,7 @@ TTBIN_FILE *parse_ttbin_data(uint8_t *data, uint32_t size)
     if (*data++ != TAG_FILE_HEADER)
         return 0;
 
-    file = malloc(sizeof(TTBIN_FILE));
-    memset(file, 0, sizeof(TTBIN_FILE));
+    file = calloc(1, sizeof(TTBIN_FILE));
 
     file_header = (FILE_HEADER*)data;
     data += sizeof(FILE_HEADER) + (file_header->length_count - 1) * sizeof(RECORD_LENGTH);
@@ -558,8 +557,7 @@ int write_ttbin_file(const TTBIN_FILE *ttbin, FILE *file)
 
     /* create and write the file header */
     size = sizeof(FILE_HEADER) + 29 * sizeof(RECORD_LENGTH);
-    header = (FILE_HEADER*)malloc(size);
-    memset(header, 0, size);
+    header = (FILE_HEADER*)calloc(1, size);
     header->file_version = ttbin->file_version;
     memcpy(header->firmware_version, ttbin->firmware_version, sizeof(header->firmware_version));
     header->product_id = ttbin->product_id;
@@ -1044,7 +1042,7 @@ void free_ttbin(TTBIN_FILE *ttbin)
 
     if (!ttbin)
         return;
-        
+
     for (record = ttbin->first; record; record = record->next)
     {
         if (record->prev)


### PR DESCRIPTION
Some cosmetic changes:

Use calloc(1, sizeof(block)) instead of malloc(sizeof(block)) & memset(ptr, 0, sizeof(block))
They are equivalent and calloc seems to be faster on most systems
http://stackoverflow.com/questions/2688466/why-mallocmemset-is-slower-than-calloc for example