### PR TITLE
Support reading&exporting Indoor cycling activity into CSV

### DIFF
--- a/include/ttbin.h
+++ b/include/ttbin.h
@@ -357,6 +357,7 @@ typedef struct
     int gps_ok;
     int treadmill_ok;
     int pool_swim_ok;
+    int indoor_ok;
     void (*producer)(TTBIN_FILE* ttbin, FILE *file);
 } OFFLINE_FORMAT;
 

--- a/include/ttbin.h
+++ b/include/ttbin.h
@@ -39,6 +39,7 @@
 #define ACTIVITY_TREADMILL  (7)
 #define ACTIVITY_FREESTYLE  (8)
 #define ACTIVITY_GYM        (9)
+#define ACTIVITY_INDOOR     (11)
 
 typedef struct
 {

--- a/include/ttbin.h
+++ b/include/ttbin.h
@@ -30,6 +30,7 @@
 #define TAG_RACE_RESULT         (0x3d)
 #define TAG_ALTITUDE_UPDATE     (0x3e)
 #define TAG_HEART_RATE_RECOVERY (0x3f)
+#define TAG_INDOOR_CYCLING      (0x40)
 #define TAG_GYM                 (0x41)
 
 #define ACTIVITY_RUNNING    (0)
@@ -220,6 +221,14 @@ typedef struct
 
 typedef struct
 {
+    uint32_t timestamp;
+    float    distance_meters;
+    uint16_t calories;
+    uint16_t cycling_cadence;
+} INDOOR_CYCLING_RECORD;
+
+typedef struct
+{
     time_t   timestamp;     /* utc time */
     uint16_t length;
     uint8_t  *data;
@@ -253,6 +262,7 @@ typedef struct _TTBIN_RECORD
         POOL_SIZE_RECORD           pool_size;
         WHEEL_SIZE_RECORD          wheel_size;
         CYCLING_CADENCE_RECORD     cycling_cadence;
+        INDOOR_CYCLING_RECORD      indoor_cycling;
     };
 } TTBIN_RECORD;
 

--- a/src/export_csv.c
+++ b/src/export_csv.c
@@ -140,6 +140,14 @@ void export_csv(TTBIN_FILE *ttbin, FILE *file)
                 fprintf(file, ",%d:%02d,,\r\n", time / 60, time % 60);
         }
         break;
+
+    case ACTIVITY_INDOOR:
+        for (record = ttbin->first; record; record = record->next)
+        {
+            fprintf(file, "record %x length %d %x\r\n", record->tag, record->length, (unsigned int)record->data[1]);
+        }
+        break;
     }
+
 }
 

--- a/src/export_csv.c
+++ b/src/export_csv.c
@@ -156,6 +156,9 @@ void export_csv(TTBIN_FILE *ttbin, FILE *file)
             case TAG_WHEEL_SIZE:
                 cc_set_wheel_size(&cc_data, &record->wheel_size);
                 break;
+            case TAG_LAP:
+                ++current_lap;
+                break;
             case TAG_INDOOR_CYCLING:
                 timestamp = record->indoor_cycling.timestamp;
                 strftime(timestr, sizeof(timestr), "%FT%X", localtime(&timestamp));

--- a/src/export_csv.c
+++ b/src/export_csv.c
@@ -17,6 +17,7 @@ void export_csv(TTBIN_FILE *ttbin, FILE *file)
     unsigned heart_rate;
     double distance_factor = 1;
     unsigned time;
+    time_t timestamp;
     CyclingCadenceData cc_data = cc_initialize();
 
     fputs("time,activityType,lapNumber,distance,speed,calories,lat,long,elevation,heartRate,cycles,localtime,elapsedTime,cyclingCadence,wheelSpeed\r\n", file);
@@ -144,7 +145,37 @@ void export_csv(TTBIN_FILE *ttbin, FILE *file)
     case ACTIVITY_INDOOR:
         for (record = ttbin->first; record; record = record->next)
         {
-            fprintf(file, "record %x length %d %x\r\n", record->tag, record->length, (unsigned int)record->data[1]);
+          switch (record->tag)
+            {
+            case TAG_HEART_RATE:
+                heart_rate = record->heart_rate.heart_rate;
+                break;
+            case TAG_CYCLING_CADENCE:
+                cc_sensor_packet(&cc_data, &record->cycling_cadence);
+                break;
+            case TAG_WHEEL_SIZE:
+                cc_set_wheel_size(&cc_data, &record->wheel_size);
+                break;
+            case TAG_INDOOR_CYCLING:
+                timestamp = record->indoor_cycling.timestamp;
+                strftime(timestr, sizeof(timestr), "%FT%X", localtime(&timestamp));
+                time = (unsigned)(record->indoor_cycling.timestamp - ttbin->timestamp_local);
+                fprintf(file, "%u,11,%u,%.2f,%.2f,%u,,,,%u,%u,%s",
+                    time,
+                    current_lap,
+                    record->indoor_cycling.distance_meters,
+                    cc_data.wheel_speed,
+                    record->indoor_cycling.calories,
+                    heart_rate,
+                    record->indoor_cycling.cycling_cadence,
+                    timestr
+                );
+                if (time >= 3600)
+                    fprintf(file, ",%d:%02d:%02d,,\r\n", time / 3600, (time % 3600) / 60, time % 60);
+                else
+                    fprintf(file, ",%d:%02d,,\r\n", time / 60, time % 60);
+                break;
+            }
         }
         break;
     }

--- a/src/ttbin.c
+++ b/src/ttbin.c
@@ -19,12 +19,12 @@
 /*****************************************************************************/
 
 const OFFLINE_FORMAT OFFLINE_FORMATS[OFFLINE_FORMAT_COUNT] = {
-    { OFFLINE_FORMAT_CSV, "csv", 1, 1, 1, export_csv },
-    { OFFLINE_FORMAT_FIT, "fit", 1, 0, 0, 0          },
-    { OFFLINE_FORMAT_GPX, "gpx", 1, 0, 0, export_gpx },
-    { OFFLINE_FORMAT_KML, "kml", 1, 0, 0, export_kml },
-    { OFFLINE_FORMAT_PWX, "pwx", 1, 0, 0, 0          },
-    { OFFLINE_FORMAT_TCX, "tcx", 1, 1, 0, export_tcx },
+    { OFFLINE_FORMAT_CSV, "csv", 1, 1, 1, 1, export_csv },
+    { OFFLINE_FORMAT_FIT, "fit", 1, 0, 0, 0, 0          },
+    { OFFLINE_FORMAT_GPX, "gpx", 1, 0, 0, 0, export_gpx },
+    { OFFLINE_FORMAT_KML, "kml", 1, 0, 0, 0, export_kml },
+    { OFFLINE_FORMAT_PWX, "pwx", 1, 0, 0, 0, 0          },
+    { OFFLINE_FORMAT_TCX, "tcx", 1, 1, 0, 0, export_tcx },
 };
 
 /*****************************************************************************/

--- a/src/ttbin.c
+++ b/src/ttbin.c
@@ -870,6 +870,7 @@ const char *create_filename(TTBIN_FILE *ttbin, const char *ext)
     case ACTIVITY_TREADMILL: type = "Treadmill"; break;
     case ACTIVITY_FREESTYLE: type = "Freestyle"; break;
     case ACTIVITY_GYM:       type = "Gym"; break;
+    case ACTIVITY_INDOOR:    type = "Indoor"; break;
     }
     sprintf(filename, "%s_%02d-%02d-%02d.%s", type, time->tm_hour, time->tm_min, time->tm_sec, ext);
 

--- a/src/ttbincnv.c
+++ b/src/ttbincnv.c
@@ -207,7 +207,9 @@ int main(int argc, char *argv[])
         {
             if ((OFFLINE_FORMATS[i].gps_ok && ttbin->gps_records.count)
                 || (OFFLINE_FORMATS[i].treadmill_ok && (ttbin->activity == ACTIVITY_TREADMILL))
-                || (OFFLINE_FORMATS[i].pool_swim_ok && (ttbin->activity == ACTIVITY_SWIMMING)))
+                || (OFFLINE_FORMATS[i].pool_swim_ok && (ttbin->activity == ACTIVITY_SWIMMING))
+                || (OFFLINE_FORMATS[i].indoor_ok && (ttbin->activity == ACTIVITY_INDOOR))
+                )
             {
                 FILE *output_file = stdout;
                 if (!pipe_mode)


### PR DESCRIPTION
Implement exporting indoor cycling activities to CSV files.

The structure of `0x40` tag is as follows:
```
typedef struct
{
    uint32_t timestamp;
    float    distance_meters;
    uint16_t calories;
    uint16_t cycling_cadence;
} INDOOR_CYCLING_RECORD;
```

Related to #108 (TCX would be a second step)

Example test file with heart rate & cadence data:
[Indoor_22-29-42.ttbin.zip](https://github.com/ryanbinns/ttwatch/files/706329/Indoor_22-29-42.ttbin.zip)

