### PR TITLE
Export indoor cycling activity into TCX files

### DIFF
--- a/src/export_csv.c
+++ b/src/export_csv.c
@@ -143,6 +143,7 @@ void export_csv(TTBIN_FILE *ttbin, FILE *file)
         break;
 
     case ACTIVITY_INDOOR:
+    case ACTIVITY_GYM:
         for (record = ttbin->first; record; record = record->next)
         {
           switch (record->tag)
@@ -171,6 +172,23 @@ void export_csv(TTBIN_FILE *ttbin, FILE *file)
                     record->indoor_cycling.calories,
                     heart_rate,
                     record->indoor_cycling.cycling_cadence,
+                    timestr
+                );
+                if (time >= 3600)
+                    fprintf(file, ",%d:%02d:%02d,,\r\n", time / 3600, (time % 3600) / 60, time % 60);
+                else
+                    fprintf(file, ",%d:%02d,,\r\n", time / 60, time % 60);
+                break;
+            case TAG_GYM:
+                timestamp = record->gym.timestamp;
+                strftime(timestr, sizeof(timestr), "%FT%X", localtime(&timestamp));
+                time = (unsigned)(record->indoor_cycling.timestamp - ttbin->timestamp_local);
+                fprintf(file, "%u,9,%u,,,%u,,,,%u,%u,%s",
+                    time,
+                    current_lap,
+                    record->gym.total_calories,
+                    heart_rate,
+                    record->gym.total_cycles,
                     timestr
                 );
                 if (time >= 3600)

--- a/src/export_tcx.c
+++ b/src/export_tcx.c
@@ -98,7 +98,7 @@ void export_tcx(TTBIN_FILE *ttbin, FILE *file)
             }
         }
     }
-    else if (ttbin->activity == ACTIVITY_INDOOR)
+    else if (ttbin->activity == ACTIVITY_INDOOR || ttbin->activity == ACTIVITY_GYM)
     {
 
     }
@@ -122,6 +122,7 @@ void export_tcx(TTBIN_FILE *ttbin, FILE *file)
     case ACTIVITY_TREADMILL: fputs("Running", file);   break; /* per Garmin spec, not "Treadmill" */
     case ACTIVITY_FREESTYLE: fputs("Freestyle", file); break;
     case ACTIVITY_INDOOR:    fputs("Biking", file);    break;
+    case ACTIVITY_GYM:       fputs("Gym",file);        break;
     default:                 fputs("Unknown", file);   break;
     }
     fputs("\">\r\n"
@@ -153,6 +154,7 @@ void export_tcx(TTBIN_FILE *ttbin, FILE *file)
         case TAG_TREADMILL:
         case TAG_INDOOR_CYCLING:
         case TAG_GPS:
+        case TAG_GYM:
             if (record->tag == TAG_TREADMILL)
             {
                 /* this will happen if the activity is paused and then resumed */
@@ -165,6 +167,17 @@ void export_tcx(TTBIN_FILE *ttbin, FILE *file)
                 total_step_count += steps;
                 timestamp = record->treadmill.timestamp;
                 distance = record->treadmill.distance * distance_factor;
+            }
+            else if (record->tag == TAG_GYM)
+            {
+                if (record->gym.timestamp == 0)
+                    break;
+
+                steps = record->gym.total_cycles - steps_prev;
+                steps_prev = record->gym.total_cycles;
+
+                total_step_count += steps;
+                timestamp = record->gym.timestamp;
             }
             else if (record->tag == TAG_INDOOR_CYCLING)
             {

--- a/src/export_tcx.c
+++ b/src/export_tcx.c
@@ -98,6 +98,10 @@ void export_tcx(TTBIN_FILE *ttbin, FILE *file)
             }
         }
     }
+    else if (ttbin->activity == ACTIVITY_INDOOR)
+    {
+
+    }
     else if (!ttbin->gps_records.count)
         return;
 
@@ -117,6 +121,7 @@ void export_tcx(TTBIN_FILE *ttbin, FILE *file)
     case ACTIVITY_SWIMMING:  fputs("Pool Swim", file); break;
     case ACTIVITY_TREADMILL: fputs("Running", file);   break; /* per Garmin spec, not "Treadmill" */
     case ACTIVITY_FREESTYLE: fputs("Freestyle", file); break;
+    case ACTIVITY_INDOOR:    fputs("Biking", file);    break;
     default:                 fputs("Unknown", file);   break;
     }
     fputs("\">\r\n"
@@ -146,6 +151,7 @@ void export_tcx(TTBIN_FILE *ttbin, FILE *file)
             break;
 
         case TAG_TREADMILL:
+        case TAG_INDOOR_CYCLING:
         case TAG_GPS:
             if (record->tag == TAG_TREADMILL)
             {
@@ -159,6 +165,13 @@ void export_tcx(TTBIN_FILE *ttbin, FILE *file)
                 total_step_count += steps;
                 timestamp = record->treadmill.timestamp;
                 distance = record->treadmill.distance * distance_factor;
+            }
+            else if (record->tag == TAG_INDOOR_CYCLING)
+            {
+                if (record->indoor_cycling.timestamp == 0)
+                    break;
+                distance = record->indoor_cycling.distance_meters;
+                timestamp = record->indoor_cycling.timestamp;
             }
             else /* TAG_GPS only */
             {

--- a/src/ttbin.c
+++ b/src/ttbin.c
@@ -24,7 +24,7 @@ const OFFLINE_FORMAT OFFLINE_FORMATS[OFFLINE_FORMAT_COUNT] = {
     { OFFLINE_FORMAT_GPX, "gpx", 1, 0, 0, 0, export_gpx },
     { OFFLINE_FORMAT_KML, "kml", 1, 0, 0, 0, export_kml },
     { OFFLINE_FORMAT_PWX, "pwx", 1, 0, 0, 0, 0          },
-    { OFFLINE_FORMAT_TCX, "tcx", 1, 1, 0, 0, export_tcx },
+    { OFFLINE_FORMAT_TCX, "tcx", 1, 1, 0, 1, export_tcx },
 };
 
 /*****************************************************************************/

--- a/src/ttbincnv.c
+++ b/src/ttbincnv.c
@@ -208,7 +208,7 @@ int main(int argc, char *argv[])
             if ((OFFLINE_FORMATS[i].gps_ok && ttbin->gps_records.count)
                 || (OFFLINE_FORMATS[i].treadmill_ok && (ttbin->activity == ACTIVITY_TREADMILL))
                 || (OFFLINE_FORMATS[i].pool_swim_ok && (ttbin->activity == ACTIVITY_SWIMMING))
-                || (OFFLINE_FORMATS[i].indoor_ok && (ttbin->activity == ACTIVITY_INDOOR))
+                || (OFFLINE_FORMATS[i].indoor_ok && (ttbin->activity == ACTIVITY_INDOOR || ttbin->activity == ACTIVITY_GYM))
                 )
             {
                 FILE *output_file = stdout;


### PR DESCRIPTION
Fixes #108 
Exported file uploaded OK to Strava.
Heart rate, cadence info & distance are fully supported

Example output file:
[Indoor_22-29-42.tcx.zip](https://github.com/ryanbinns/ttwatch/files/722135/Indoor_22-29-42.tcx.zip)

Fixes #68 
Example input & output files:
[Gym_11-41-14.ttbin.zip](https://github.com/ryanbinns/ttwatch/files/722172/Gym_11-41-14.ttbin.zip)
[gym_export.zip](https://github.com/ryanbinns/ttwatch/files/722171/gym_export.zip)

