### PR TITLE
fixes for the install_udev target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,7 +95,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
   add_custom_target(install_udev
     COMMAND cp 99-tomtom.rules /etc/udev/rules.d
     COMMAND udevadm control --reload-rules
-    COMMAND addgroup usb
+    COMMAND addgroup --system usb
     COMMAND usermod -a -Gusb `logname`
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,7 +91,7 @@ else()
 endif(daemon)
 install(FILES ttbin2mysports DESTINATION bin)
 
-if(${CMAKE_SYSTEM_NAME} EQUAL "Linux")
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
   add_custom_target(install_udev
     COMMAND cp 99-tomtom.rules /etc/udev/rules.d
     COMMAND udevadm control --reload-rules


### PR DESCRIPTION
- fixed the logic to enable/disable `install_udev`
- create the `usb` group with a system GID