### PR TITLE
Fix support for writing new file format files

### DIFF
--- a/include/ttbin.h
+++ b/include/ttbin.h
@@ -33,6 +33,7 @@
 #define TAG_INDOOR_CYCLING      (0x40)
 #define TAG_GYM                 (0x41)
 #define TAG_FITNESS_POINT       (0x4a)
+#define TAG_UNKNOWN_4B_VAR_LEN  (0x4b)
 
 #define ACTIVITY_RUNNING    	(0)
 #define ACTIVITY_CYCLING    	(1)


### PR DESCRIPTION
This should now allow for writing files in the new format (10), and also the old format ( <= 9) again, which I broke with #134.