### PR TITLE
Use cumulative distance to calculate interval/lap distance

### DIFF
--- a/src/ttbin.c
+++ b/src/ttbin.c
@@ -179,7 +179,7 @@ typedef struct __attribute__((packed))
 
 typedef struct __attribute__((packed))
 {
-    uint8_t  type;              /* 1 = warmup, 2 = work, 3 = rest, 4 = cooldown */
+    int16_t  type;              /* 1 = warmup, 2 = work, 3 = rest, 4 = cooldown */
     uint32_t total_time;        /* seconds */
     float    total_distance;    /* metres */
     uint16_t total_calories;


### PR DESCRIPTION
Reported distances are unreliable, this commit changes the code to calculate the interval distance based on the start/end cumulative distances.

Fixes #159