### PR TITLE
Provide alternative way for GPQQuickFix info

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,11 @@ Applicable options (*not* case sensitive) and their values are as follows:
 7. Ephemeris7Days: specifies that a 7-day GPS ephemeris should be uploaded
                    to the watch, rather than the default 3-day ephemeris.
                    This is a boolean value.
+8. EphemerisURL: specifies the URL from which to obtain the QuickGPS
+                   ephemeris data.  A value that seems to work is
+		   `https://gpsquickfix.services.tomtom.com/fitness/sifgps.f2p{DAYS}enc.ee`.
+		   The `{DAYS}` part is changed according the the setting of
+		   `Ephemeris7Days`.
 
 The following options only take effect when running the `ttwatchd` daemon:
 
@@ -342,9 +347,10 @@ user and group, and normal activities when a watch is connected could be:
 ActivityStore = /mnt/data/watch
 RunAsUser = jsmith:usb
 GetActivities = true
-UpdateFirmware = true
+UpdateFirmware = false
 UpdateGPS = true
 SetTime = true
+EphemerisURL = https://gpsquickfix.services.tomtom.com/fitness/sifgps.f2p{DAYS}enc.ee
 ```
 A per-user config file could be added to specify a list of file formats to make:
 ```

--- a/include/options.h
+++ b/include/options.h
@@ -53,6 +53,7 @@ typedef struct
     int list_settings;
     int skip_elevation;
     char *post_processor;
+    char *ephemeris_url;
     int factory_reset;
     int initial_setup;
     int force;

--- a/include/update_gps.h
+++ b/include/update_gps.h
@@ -9,6 +9,6 @@
 #include "libttwatch.h"
 
 /******************************************************************************/
-void do_update_gps(TTWATCH *watch, int eph_7_days);
+void do_update_gps(TTWATCH *watch, int eph_7_days, const char *url);
 
 #endif  /* __UPDATE_GPS_H__ */

--- a/src/options.c
+++ b/src/options.c
@@ -131,6 +131,12 @@ void load_conf_file(const char *filename, OPTIONS *options, ConfLoadType load_ty
             options->formats = parse_format_list(value);
             result = 1;
         }
+        else if (!strcasecmp(option, "EphemerisURL"))
+        {
+            options->ephemeris_url = value;
+            value = 0;
+            result = 1;
+        }
         else if (!strcasecmp(option, "PostProcessor"))
         {
             options->post_processor = value;

--- a/src/ttwatch.c
+++ b/src/ttwatch.c
@@ -1754,7 +1754,7 @@ int main(int argc, char *argv[])
     }
 
     if (options->update_gps)
-        do_update_gps(watch, options->eph_7_days);
+        do_update_gps(watch, options->eph_7_days, options->ephemeris_url);
 
     if (options->update_firmware)
     {

--- a/src/ttwatchd.c
+++ b/src/ttwatchd.c
@@ -57,7 +57,7 @@ void daemon_watch_operations(TTWATCH *watch, OPTIONS *options)
     }
 
     if (new_options->update_gps)
-        do_update_gps(watch, options->eph_7_days);
+        do_update_gps(watch, options->eph_7_days, options->ephemeris_url);
 
     if (new_options->update_firmware)
         do_update_firmware(watch, 0);

--- a/src/update_gps.c
+++ b/src/update_gps.c
@@ -11,22 +11,23 @@
 #include <stdlib.h>
 
 /*****************************************************************************/
-void do_update_gps(TTWATCH *watch, int eph_7_days)
+void do_update_gps(TTWATCH *watch, int eph_7_days, const char *url)
 {
     DOWNLOAD download = {0};
-    char *url = 0;
+    char *original_url;
 
-    url = get_config_string(watch, "service:ephemeris");
     if (!url)
     {
-        write_log(1, "Unable to get GPSQuickFix data URL\n");
+        write_log(1, "GPSQuickFix data URL option EphemerisURL not configured\n");
         return;
     }
+
+    original_url = strdup(url);
     /* get days ephemeris */
     if (eph_7_days)
-        url = replace(url, "{DAYS}", "7");
+        url = replace(original_url, "{DAYS}", "7");
     else
-        url = replace(url, "{DAYS}", "3");
+        url = replace(original_url, "{DAYS}", "3");
 
     /* download the data file */
     write_log(0, "Downloading GPSQuickFix data file...\n");


### PR DESCRIPTION
The TomTom configuration file is no longer available.  Add a configuration option to set the URL of the file that is still provided by TomTom.