### PR TITLE
add string.h to update_gps.c

### DIFF
--- a/src/update_gps.c
+++ b/src/update_gps.c
@@ -9,6 +9,7 @@
 #include "log.h"
 
 #include <stdlib.h>
+#include <string.h>
 
 /*****************************************************************************/
 void do_update_gps(TTWATCH *watch, int eph_7_days, const char *url)


### PR DESCRIPTION
Don't have any experience with C, but when I tried to `make` the latest version (on MacOS Monterey) I got an error and the compiler told me to
```
include the header <string.h> or explicitly provide a declaration for 'strdup'
```
I did and it worked.